### PR TITLE
[GLB-55] 에디터 화면 Google Analytics 이벤트 적용

### DIFF
--- a/src/components/imageMetadata/DateSelectBottomSheet.tsx
+++ b/src/components/imageMetadata/DateSelectBottomSheet.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { sendGAEvent } from "@next/third-parties/google";
 
 import { DateSelectFormData, dateSelectSchema, extractDigits, formatYearMonth } from "@/schemas/date";
 
@@ -13,9 +14,17 @@ type DateSelectBottomSheetProps = {
   isOpen: boolean;
   onClose: () => void;
   onConfirm?: (date: string) => void;
+  photoIndex?: number;
+  hasExistingDate?: boolean;
 };
 
-export const DateSelectBottomSheet = ({ isOpen, onClose, onConfirm }: DateSelectBottomSheetProps) => {
+export const DateSelectBottomSheet = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  photoIndex = 0,
+  hasExistingDate = false,
+}: DateSelectBottomSheetProps) => {
   const {
     watch,
     setValue,
@@ -35,22 +44,49 @@ export const DateSelectBottomSheet = ({ isOpen, onClose, onConfirm }: DateSelect
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const digits = extractDigits(event.target.value);
+      const overLimit = digits.length > 6;
 
-      if (digits.length <= 6) {
+      if (!overLimit) {
         const formatted = formatYearMonth(digits);
         setValue("date", formatted, { shouldValidate: true });
+        sendGAEvent("event", "record_meta_date_input_change", {
+          flow: "editor",
+          screen: "record_edit_meta_date",
+          click_code: "editor.record.edit.meta.date.input.change",
+          photo_index: photoIndex,
+          input_length: formatted.length,
+          is_valid_format: /^\d{4}\.\d{2}$/.test(formatted),
+          over_limit_attempt: false,
+        });
+      } else {
+        sendGAEvent("event", "record_meta_date_input_change", {
+          flow: "editor",
+          screen: "record_edit_meta_date",
+          click_code: "editor.record.edit.meta.date.input.change",
+          photo_index: photoIndex,
+          input_length: dateValue.length,
+          is_valid_format: /^\d{4}\.\d{2}$/.test(dateValue),
+          over_limit_attempt: true,
+        });
       }
     },
-    [setValue]
+    [setValue, photoIndex, dateValue]
   );
 
   const onSubmit = useCallback(
     (data: DateSelectFormData) => {
+      sendGAEvent("event", "record_meta_date_confirm", {
+        flow: "editor",
+        screen: "record_edit_meta_date",
+        click_code: "editor.record.edit.meta.date.cta.confirm",
+        photo_index: photoIndex,
+        has_value: true,
+      });
       onConfirm?.(data.date);
       onClose();
       reset({ date: "" });
     },
-    [onConfirm, onClose, reset]
+    [onConfirm, onClose, reset, photoIndex]
   );
 
   const handleClose = useCallback(() => {
@@ -58,10 +94,18 @@ export const DateSelectBottomSheet = ({ isOpen, onClose, onConfirm }: DateSelect
     reset({ date: "" });
   }, [onClose, reset]);
 
-  // 바텀시트가 열릴 때 폼 리셋
+  // 바텀시트가 열릴 때 폼 리셋 + view 이벤트
   useEffect(() => {
-    if (isOpen) reset({ date: "" });
-  }, [isOpen, reset]);
+    if (isOpen) {
+      sendGAEvent("event", "record_meta_date_view", {
+        flow: "editor",
+        screen: "record_edit_meta_date",
+        photo_index: photoIndex,
+        has_value: hasExistingDate,
+      });
+      reset({ date: "" });
+    }
+  }, [isOpen, reset, photoIndex, hasExistingDate]);
 
   return (
     <BaseInputBottomSheet

--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -272,12 +272,15 @@ export const ImageCarousel = ({
         onClose={() => setIsLocationSelectModalOpen(false)}
         onConfirm={handleConfirmLocation}
         initialLocation={initialLocationSelection}
+        photoIndex={photoIndex}
+        hasExistingLocation={hasLocation}
       />
       {isCropModalOpen && (
         <ImageCropModal
           image={image.originalImageUrl || currentImage}
           onClose={() => setIsCropModalOpen(false)}
           onSave={handleSaveCroppedImage}
+          photoIndex={photoIndex}
         />
       )}
     </div>

--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -30,6 +30,7 @@ type ImageCarouselProps = {
   onImageUpdate?: (id: string, croppedImage: string) => void | Promise<void>;
   onLocationChange?: (location: LocationSelection | null) => void;
   isProcessing?: boolean;
+  photoIndex?: number;
 };
 
 export const ImageCarousel = ({
@@ -40,6 +41,7 @@ export const ImageCarousel = ({
   onImageUpdate,
   onLocationChange,
   isProcessing = false,
+  photoIndex = 0,
 }: ImageCarouselProps) => {
   const [selectedTag, setSelectedTag] = useState<ImageTag | null>(
     image.selectedTag ?? (image.tag && image.tag !== "NONE" ? image.tag : null)
@@ -262,6 +264,8 @@ export const ImageCarousel = ({
         isOpen={isDateSelectModalOpen}
         onClose={() => setIsDateSelectModalOpen(false)}
         onConfirm={handleConfirmDate}
+        photoIndex={photoIndex}
+        hasExistingDate={hasDate}
       />
       <LocationSelectBottomSheet
         isOpen={isLocationSelectModalOpen}

--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -155,7 +155,7 @@ export const ImageCarousel = ({
     sendGAEvent("event", "record_meta_location_change", {
       flow: "editor",
       screen: "record_edit",
-      click_code: "editor.record.edit.meta.location",
+      click_code: "editor.record.edit.meta.location.remove",
       location_before: customLocation || null,
       location_after: null,
       change_type: "remove",

--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 
+import { sendGAEvent } from "@next/third-parties/google";
+
 import type { ImageMetadata, ImageTag } from "@/types/imageMetadata";
 import { formatYearMonth, toYearMonth } from "@/utils/dateUtils";
 
@@ -75,6 +77,12 @@ export const ImageCarousel = ({
   }, [image.imagePreview]);
 
   const handleTagSelect = (tag: ImageTag) => {
+    sendGAEvent("event", "record_tag_select", {
+      flow: "editor",
+      screen: "record_edit",
+      click_code: "editor.record.edit.tag.select",
+      tag_type: tag.toLowerCase(),
+    });
     setSelectedTag(tag);
     onTagChange?.(tag);
   };
@@ -84,13 +92,35 @@ export const ImageCarousel = ({
     onTagChange?.(null);
   };
 
+  const formatDateForGA = (yyyymm: string | null): string | null => {
+    if (!yyyymm) return null;
+    return `${yyyymm.slice(0, 4)}.${yyyymm.slice(4, 6)}`;
+  };
+
   const handleConfirmDate = (date: string) => {
     const normalized = date.replace(".", "");
+    const changeType = !customDate ? "add" : "update";
+    sendGAEvent("event", "record_meta_date_change", {
+      flow: "editor",
+      screen: "record_edit",
+      click_code: "editor.record.edit.meta.date.edit",
+      date_before: formatDateForGA(customDate),
+      date_after: formatDateForGA(normalized),
+      change_type: changeType,
+    });
     setCustomDate(normalized);
     onDateChange?.(normalized);
   };
 
   const handleDateClear = () => {
+    sendGAEvent("event", "record_meta_date_change", {
+      flow: "editor",
+      screen: "record_edit",
+      click_code: "editor.record.edit.meta.date.remove",
+      date_before: formatDateForGA(customDate),
+      date_after: null,
+      change_type: "remove",
+    });
     setCustomDate(null);
     onDateChange?.(null);
   };
@@ -106,11 +136,28 @@ export const ImageCarousel = ({
 
   const handleConfirmLocation = (location: LocationSelection) => {
     const displayName = location.name || location.address;
+    const changeType = !customLocation ? "add" : "update";
+    sendGAEvent("event", "record_meta_location_change", {
+      flow: "editor",
+      screen: "record_edit",
+      click_code: "editor.record.edit.meta.location.edit",
+      location_before: customLocation || null,
+      location_after: displayName || null,
+      change_type: changeType,
+    });
     setCustomLocation(displayName);
     onLocationChange?.(location);
   };
 
   const handleLocationClear = () => {
+    sendGAEvent("event", "record_meta_location_change", {
+      flow: "editor",
+      screen: "record_edit",
+      click_code: "editor.record.edit.meta.location",
+      location_before: customLocation || null,
+      location_after: null,
+      change_type: "remove",
+    });
     setCustomLocation(null);
     onLocationChange?.(null);
   };
@@ -156,7 +203,14 @@ export const ImageCarousel = ({
         <button
           type="button"
           className="w-full h-full bg-black relative cursor-pointer overflow-hidden"
-          onClick={() => setIsCropModalOpen(true)}
+          onClick={() => {
+            sendGAEvent("event", "record_photo_ratio_entry", {
+              flow: "editor",
+              screen: "record_edit",
+              click_code: "editor.record.edit.photo.open_ratio",
+            });
+            setIsCropModalOpen(true);
+          }}
           aria-label="이미지 편집"
           disabled={isCropUploading}
         >

--- a/src/components/imageMetadata/ImageCropModal.tsx
+++ b/src/components/imageMetadata/ImageCropModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Area } from "react-easy-crop";
 import Cropper from "react-easy-crop";
+
+import { sendGAEvent } from "@next/third-parties/google";
 
 import { Header } from "../common/Header";
 
@@ -10,13 +12,36 @@ type ImageCropModalProps = {
   image: string;
   onClose: () => void;
   onSave: (croppedImage: string) => void;
+  photoIndex?: number;
 };
 
-export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) => {
+export const ImageCropModal = ({ image, onClose, onSave, photoIndex = 0 }: ImageCropModalProps) => {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [imageBlobUrl, setImageBlobUrl] = useState<string | null>(null);
+
+  const interactionCountRef = useRef(0);
+  const interactionDurationRef = useRef(0);
+  const gestureStartTimeRef = useRef<number | null>(null);
+  const zoomChangedInGestureRef = useRef(false);
+  const gestureEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    sendGAEvent("event", "record_crop_view", {
+      flow: "editor",
+      screen: "record_edit_crop",
+      photo_index: photoIndex,
+    });
+  }, [photoIndex]);
+
+  useEffect(() => {
+    return () => {
+      if (gestureEndTimerRef.current) {
+        clearTimeout(gestureEndTimerRef.current);
+      }
+    };
+  }, []);
 
   const onCropComplete = useCallback((_croppedArea: Area, croppedAreaPixels: Area) => {
     setCroppedAreaPixels(croppedAreaPixels);
@@ -51,8 +76,66 @@ export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) 
     };
   }, [image, onClose]);
 
+  const handleGestureActivity = (isZoom: boolean) => {
+    const now = Date.now();
+
+    if (gestureStartTimeRef.current === null) {
+      gestureStartTimeRef.current = now;
+      zoomChangedInGestureRef.current = false;
+    }
+
+    if (isZoom) {
+      zoomChangedInGestureRef.current = true;
+    }
+
+    if (gestureEndTimerRef.current) {
+      clearTimeout(gestureEndTimerRef.current);
+    }
+
+    gestureEndTimerRef.current = setTimeout(() => {
+      const duration = Date.now() - (gestureStartTimeRef.current ?? now);
+      const gestureType = zoomChangedInGestureRef.current ? "zoom" : "drag";
+
+      interactionCountRef.current += 1;
+      interactionDurationRef.current += duration;
+
+      sendGAEvent("event", "record_crop_interaction", {
+        flow: "editor",
+        screen: "record_edit_crop",
+        click_code:
+          gestureType === "drag" ? "editor.record.edit.crop.gesture.move" : "editor.record.edit.crop.gesture.zoom",
+        photo_index: photoIndex,
+        gesture_type: gestureType,
+        interaction_count: interactionCountRef.current,
+        interaction_duration: interactionDurationRef.current,
+      });
+
+      gestureStartTimeRef.current = null;
+      gestureEndTimerRef.current = null;
+    }, 300);
+  };
+
+  const handleCropChange = (newCrop: { x: number; y: number }) => {
+    setCrop(newCrop);
+    handleGestureActivity(false);
+  };
+
+  const handleZoomChange = (newZoom: number) => {
+    setZoom(newZoom);
+    handleGestureActivity(true);
+  };
+
   const createCroppedImage = async () => {
     if (!croppedAreaPixels || !imageBlobUrl) return;
+
+    const modified = interactionCountRef.current > 0;
+    sendGAEvent("event", "record_crop_complete", {
+      flow: "editor",
+      screen: "record_edit_crop",
+      click_code: "editor.record.edit.crop.header.complete",
+      interaction_count: interactionCountRef.current,
+      modified,
+    });
 
     try {
       const croppedImage = await getCroppedImg(imageBlobUrl, croppedAreaPixels);
@@ -62,6 +145,19 @@ export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) 
       alert("이미지 크롭에 실패했습니다. 다시 시도해주세요.");
       throw error;
     }
+  };
+
+  const handleClose = () => {
+    const modified = interactionCountRef.current > 0;
+    sendGAEvent("event", "record_crop_exit", {
+      flow: "editor",
+      screen: "record_edit_crop",
+      click_code: "editor.record.edit.crop.header.close",
+      photo_index: photoIndex,
+      interaction_count: interactionCountRef.current,
+      modified,
+    });
+    onClose();
   };
 
   if (!imageBlobUrl) {
@@ -80,7 +176,7 @@ export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) 
           <Header
             variant="dark"
             leftIcon="close"
-            onLeftClick={onClose}
+            onLeftClick={handleClose}
             rightButtonTitle="완료"
             rightButtonVariant="white"
             onRightClick={createCroppedImage}
@@ -94,9 +190,9 @@ export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) 
             crop={crop}
             zoom={zoom}
             aspect={9 / 16}
-            onCropChange={setCrop}
+            onCropChange={handleCropChange}
             onCropComplete={onCropComplete}
-            onZoomChange={setZoom}
+            onZoomChange={handleZoomChange}
             style={{
               containerStyle: {
                 width: "100%",

--- a/src/components/imageMetadata/ImageMetadata.tsx
+++ b/src/components/imageMetadata/ImageMetadata.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+
+import { sendGAEvent } from "@next/third-parties/google";
 
 import { Header } from "../common/Header";
 import { CityErrorFallback } from "./CityErrorFallback";
@@ -49,6 +52,34 @@ export const ImageMetadataComponent = ({
     handleLocationChange,
   } = useImageMetadata({ diaryId, isEditMode });
 
+  const hasSavedRef = useRef(false);
+  const metadataListRef = useRef(metadataList);
+  const diaryTextRef = useRef(diaryText);
+
+  useEffect(() => {
+    metadataListRef.current = metadataList;
+  }, [metadataList]);
+
+  useEffect(() => {
+    diaryTextRef.current = diaryText;
+  }, [diaryText]);
+
+  useEffect(() => {
+    sendGAEvent("event", "editor_record_edit_view", {
+      flow: "editor",
+      screen: "record_edit",
+    });
+    return () => {
+      sendGAEvent("event", "editor_record_edit_exit", {
+        flow: "editor",
+        screen: "record_edit",
+        has_saved: hasSavedRef.current,
+        photo_count: metadataListRef.current.length,
+        text_length: diaryTextRef.current.length,
+      });
+    };
+  }, []);
+
   const { handleSave } = useDiaryAction({
     cityId,
     diaryId,
@@ -65,6 +96,30 @@ export const ImageMetadataComponent = ({
 
   const handleBack = () => {
     router.back();
+  };
+
+  const handleRemoveWithGA = (id: string) => {
+    sendGAEvent("event", "record_photo_delete_confirm", {
+      flow: "editor",
+      screen: "record_edit",
+      click_code: "editor.record.edit.photo.delete.confirm",
+      photo_count: metadataList.length - 1,
+    });
+    handleRemove(id);
+  };
+
+  const handleSaveClick = () => {
+    const hasMetadata = metadataList.some(item => item.customDate || item.location?.address);
+    sendGAEvent("event", "record_edit_save_click", {
+      flow: "editor",
+      screen: "record_edit",
+      click_code: "editor.record.edit.header.save",
+      photo_count: metadataList.length,
+      text_length: diaryText.length,
+      has_metadata: hasMetadata,
+    });
+    hasSavedRef.current = true;
+    handleSave();
   };
 
   const handleNavigateToCitySelection = () => {
@@ -89,12 +144,12 @@ export const ImageMetadataComponent = ({
         onLeftClick={handleBack}
         rightButtonTitle="저장"
         rightButtonDisabled={!hasImages || isProcessing || isInitialLoading || !isCityIdValid}
-        onRightClick={handleSave}
+        onRightClick={handleSaveClick}
       />
       <ImageUploadSection
         metadataList={metadataList}
         fileUploadId={fileUploadId}
-        handleRemove={handleRemove}
+        handleRemove={handleRemoveWithGA}
         handleImageUpdate={handleImageUpdate}
         handleTagChange={handleTagChange}
         handleDateChange={handleDateChange}

--- a/src/components/imageMetadata/ImageMetadata.tsx
+++ b/src/components/imageMetadata/ImageMetadata.tsx
@@ -76,6 +76,7 @@ export const ImageMetadataComponent = ({
     isProcessing,
     setIsProcessing,
     pendingDeletePhotoIds,
+    hasSavedRef,
   });
 
   useEffect(() => {
@@ -127,7 +128,6 @@ export const ImageMetadataComponent = ({
       text_length: diaryText.length,
       has_metadata: hasMetadata,
     });
-    hasSavedRef.current = true;
     handleSave();
   };
 

--- a/src/components/imageMetadata/ImageMetadata.tsx
+++ b/src/components/imageMetadata/ImageMetadata.tsx
@@ -77,10 +77,18 @@ export const ImageMetadataComponent = ({
         photo_count: metadataListRef.current.length,
         text_length: diaryTextRef.current.length,
       });
+      if (saveStartedRef.current && !saveCompletedRef.current) {
+        sendGAEvent("event", "record_save_exit", {
+          flow: "editor",
+          screen: "record_save",
+          photo_count: savePhotoCountRef.current,
+          text_length: saveTextLengthRef.current,
+        });
+      }
     };
   }, []);
 
-  const { handleSave } = useDiaryAction({
+  const { handleSave, saveStartedRef, saveCompletedRef, savePhotoCountRef, saveTextLengthRef } = useDiaryAction({
     cityId,
     diaryId,
     isEditMode,

--- a/src/components/imageMetadata/ImageMetadata.tsx
+++ b/src/components/imageMetadata/ImageMetadata.tsx
@@ -64,6 +64,20 @@ export const ImageMetadataComponent = ({
     diaryTextRef.current = diaryText;
   }, [diaryText]);
 
+  const { handleSave, saveStartedRef, saveCompletedRef, savePhotoCountRef, saveTextLengthRef } = useDiaryAction({
+    cityId,
+    diaryId,
+    isEditMode,
+    uuid,
+    scrollIndex,
+    metadataList,
+    setMetadataList,
+    diaryText,
+    isProcessing,
+    setIsProcessing,
+    pendingDeletePhotoIds,
+  });
+
   useEffect(() => {
     sendGAEvent("event", "editor_record_edit_view", {
       flow: "editor",
@@ -86,21 +100,8 @@ export const ImageMetadataComponent = ({
         });
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const { handleSave, saveStartedRef, saveCompletedRef, savePhotoCountRef, saveTextLengthRef } = useDiaryAction({
-    cityId,
-    diaryId,
-    isEditMode,
-    uuid,
-    scrollIndex,
-    metadataList,
-    setMetadataList,
-    diaryText,
-    isProcessing,
-    setIsProcessing,
-    pendingDeletePhotoIds,
-  });
 
   const handleBack = () => {
     router.back();

--- a/src/components/imageMetadata/ImageUploadSection.tsx
+++ b/src/components/imageMetadata/ImageUploadSection.tsx
@@ -62,7 +62,7 @@ export const ImageUploadSection = ({
           </button>
         </div>
       )}
-      {metadataList.map(metadata => (
+      {metadataList.map((metadata, index) => (
         <div key={metadata.id} className="shrink-0">
           <ImageCarousel
             image={metadata}
@@ -71,6 +71,7 @@ export const ImageUploadSection = ({
             onTagChange={tag => handleTagChange(metadata.id, tag)}
             onDateChange={yearMonth => handleDateChange(metadata.id, yearMonth)}
             onLocationChange={location => handleLocationChange(metadata.id, location)}
+            photoIndex={index}
           />
         </div>
       ))}

--- a/src/components/imageMetadata/LocationSelectBottomSheet.tsx
+++ b/src/components/imageMetadata/LocationSelectBottomSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { sendGAEvent } from "@next/third-parties/google";
 import { Loader2 } from "lucide-react";
 
 import { SearchInput } from "@/components/common/Input";
@@ -23,6 +24,8 @@ type LocationSelectBottomSheetProps = {
   onClose: () => void;
   onConfirm?: (location: LocationSelection) => void;
   initialLocation?: LocationSelection | null;
+  photoIndex?: number;
+  hasExistingLocation?: boolean;
 };
 
 export const LocationSelectBottomSheet = ({
@@ -30,6 +33,8 @@ export const LocationSelectBottomSheet = ({
   onClose,
   onConfirm,
   initialLocation,
+  photoIndex = 0,
+  hasExistingLocation = false,
 }: LocationSelectBottomSheetProps) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [predictions, setPredictions] = useState<google.maps.places.AutocompletePrediction[]>([]);
@@ -54,6 +59,7 @@ export const LocationSelectBottomSheet = ({
   const placesServiceRef = useRef<google.maps.places.PlacesService | null>(null);
   const placesContainerRef = useRef<HTMLDivElement | null>(null);
   const wasOpenRef = useRef(false);
+  const searchAttemptCountRef = useRef(0);
 
   const isInputDisabled = useMemo(() => !isReady || isLoading || !!scriptError, [isReady, isLoading, scriptError]);
 
@@ -92,6 +98,13 @@ export const LocationSelectBottomSheet = ({
 
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {
+      searchAttemptCountRef.current = 0;
+      sendGAEvent("event", "record_meta_location_view", {
+        flow: "editor",
+        screen: "record_edit_meta_location",
+        photo_index: photoIndex,
+        has_value: hasExistingLocation,
+      });
       if (initialLocation) {
         setSelectedLocation(initialLocation);
         setActivePlaceId(initialLocation.placeId ?? null);
@@ -101,7 +114,7 @@ export const LocationSelectBottomSheet = ({
       }
     }
     wasOpenRef.current = isOpen;
-  }, [initialLocation, isOpen, resetState]);
+  }, [initialLocation, isOpen, resetState, photoIndex, hasExistingLocation]);
 
   useEffect(() => {
     if (!isOpen || !isReady) return;
@@ -222,6 +235,14 @@ export const LocationSelectBottomSheet = ({
     setSearchQuery(event.target.value);
     setSelectedLocation(null);
     setActivePlaceId(null);
+    searchAttemptCountRef.current += 1;
+    sendGAEvent("event", "record_meta_location_search", {
+      flow: "editor",
+      screen: "record_edit_meta_location",
+      click_code: "editor.record.edit.meta.location.search.input.change",
+      photo_index: photoIndex,
+      search_attempt_count: searchAttemptCountRef.current,
+    });
   };
 
   const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -233,6 +254,13 @@ export const LocationSelectBottomSheet = ({
 
   const handleConfirm = () => {
     if (!selectedLocation) return;
+    sendGAEvent("event", "record_meta_location_confirm", {
+      flow: "editor",
+      screen: "record_edit_meta_location",
+      click_code: "editor.record.edit.meta.location.cta.confirm",
+      photo_index: photoIndex,
+      has_value: true,
+    });
     onConfirm?.(selectedLocation);
     handleClose();
   };

--- a/src/components/imageMetadata/MemoryTextarea.tsx
+++ b/src/components/imageMetadata/MemoryTextarea.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState } from "react";
 
+import { sendGAEvent } from "@next/third-parties/google";
+
 import { HeadlessToast, HeadlessToastProvider } from "@/components/common/Toast";
 
 type MemoryTextareaProps = {
@@ -12,6 +14,7 @@ type MemoryTextareaProps = {
 const MAX_LENGTH = 200;
 const TOAST_DURATION = 1500;
 const TOAST_COOLDOWN = 1500;
+const TEXT_MILESTONES = [50, 100, 150, 200];
 
 export const MemoryTextarea = ({
   value,
@@ -47,8 +50,18 @@ export const MemoryTextarea = ({
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
+    const prevLength = value?.length ?? 0;
     if (newValue.length <= MAX_LENGTH) {
       onChange?.(newValue);
+      for (const milestone of TEXT_MILESTONES) {
+        if (prevLength < milestone && newValue.length >= milestone) {
+          sendGAEvent("event", "record_text_progress", {
+            flow: "editor",
+            screen: "record_edit",
+            text_length: milestone,
+          });
+        }
+      }
     } else {
       showToast();
     }

--- a/src/components/imageMetadata/hooks/useDiaryAction.ts
+++ b/src/components/imageMetadata/hooks/useDiaryAction.ts
@@ -1,6 +1,9 @@
 "use client";
 
+import { useRef } from "react";
 import { useRouter } from "next/navigation";
+
+import { sendGAEvent } from "@next/third-parties/google";
 
 import {
   useAddDiaryPhotoMutation,
@@ -94,6 +97,11 @@ export const useDiaryAction = ({
   const { mutateAsync: updateDiary } = useUpdateDiaryMutation();
   const { mutateAsync: createDiary } = useCreateDiaryMutation();
 
+  const saveStartedRef = useRef(false);
+  const saveCompletedRef = useRef(false);
+  const savePhotoCountRef = useRef(0);
+  const saveTextLengthRef = useRef(0);
+
   const isCityIdValid = typeof cityId === "number" && Number.isFinite(cityId) && cityId > 0;
 
   const handleSave = async () => {
@@ -106,6 +114,24 @@ export const useDiaryAction = ({
       alert("업로드된 이미지가 없습니다.");
       return;
     }
+
+    saveStartedRef.current = true;
+    saveCompletedRef.current = false;
+    savePhotoCountRef.current = metadataList.length;
+    saveTextLengthRef.current = diaryText.length;
+
+    const saveStartTime = Date.now();
+    const hasDate = metadataList.some(item => !!item.customDate);
+    const hasLocation = metadataList.some(item => !!(item.location?.address || item.location?.latitude));
+
+    sendGAEvent("event", "record_save_start", {
+      flow: "editor",
+      screen: "record_save",
+      photo_count: metadataList.length,
+      text_length: diaryText.length,
+      has_date: hasDate,
+      has_location: hasLocation,
+    });
 
     setIsProcessing(true);
 
@@ -224,12 +250,29 @@ export const useDiaryAction = ({
       const queryString = params.toString();
       const nextPath = queryString ? `/record/${validCityId}?${queryString}` : `/record/${validCityId}`;
 
+      sendGAEvent("event", "record_save_complete", {
+        flow: "editor",
+        screen: "record_save",
+        photo_count: metadataList.length,
+        text_length: diaryText.length,
+        duration_ms: Date.now() - saveStartTime,
+      });
+      saveCompletedRef.current = true;
+
       router.push(nextPath);
     } catch (error) {
+      saveCompletedRef.current = true;
+      const httpError = error as Error & { status?: number; statusCode?: number; code?: string };
+      const errorCode = httpError.status?.toString() ?? httpError.statusCode?.toString() ?? httpError.code ?? "UNKNOWN";
+      sendGAEvent("event", "record_save_fail", {
+        flow: "editor",
+        screen: "record_save",
+        error_code: errorCode,
+      });
       alert(error instanceof Error ? error.message : "여행기록 저장에 실패했습니다.");
       setIsProcessing(false);
     }
   };
 
-  return { handleSave };
+  return { handleSave, saveStartedRef, saveCompletedRef, savePhotoCountRef, saveTextLengthRef };
 };

--- a/src/components/imageMetadata/hooks/useDiaryAction.ts
+++ b/src/components/imageMetadata/hooks/useDiaryAction.ts
@@ -11,6 +11,7 @@ import {
   useDeleteDiaryPhotoMutation,
   useUpdateDiaryMutation,
 } from "@/hooks/mutation/useDiaryMutations";
+import { ApiError } from "@/lib/apiClient";
 import { getDiaryDetail } from "@/services/diaryService";
 import { getAuthInfo } from "@/utils/cookies";
 import { toYearMonth } from "@/utils/dateUtils";
@@ -30,6 +31,7 @@ interface UseDiaryActionProps {
   isProcessing: boolean;
   setIsProcessing: React.Dispatch<React.SetStateAction<boolean>>;
   pendingDeletePhotoIds: number[];
+  hasSavedRef?: React.MutableRefObject<boolean>;
 }
 
 const buildPhotoPayload = async (metadata: UploadMetadata, fallbackMonth: string, defaultDimension: number = 0) => {
@@ -90,6 +92,7 @@ export const useDiaryAction = ({
   isProcessing,
   setIsProcessing,
   pendingDeletePhotoIds,
+  hasSavedRef,
 }: UseDiaryActionProps) => {
   const router = useRouter();
   const { mutateAsync: deleteDiaryPhoto } = useDeleteDiaryPhotoMutation();
@@ -258,12 +261,12 @@ export const useDiaryAction = ({
         duration_ms: Date.now() - saveStartTime,
       });
       saveCompletedRef.current = true;
+      if (hasSavedRef) hasSavedRef.current = true;
 
       router.push(nextPath);
     } catch (error) {
       saveCompletedRef.current = true;
-      const httpError = error as Error & { status?: number; statusCode?: number; code?: string };
-      const errorCode = httpError.status?.toString() ?? httpError.statusCode?.toString() ?? httpError.code ?? "UNKNOWN";
+      const errorCode = error instanceof ApiError ? String(error.status) : "UNKNOWN";
       sendGAEvent("event", "record_save_fail", {
         flow: "editor",
         screen: "record_save",

--- a/src/components/imageMetadata/hooks/useImageMetadata.ts
+++ b/src/components/imageMetadata/hooks/useImageMetadata.ts
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useId, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { sendGAEvent } from "@next/third-parties/google";
+
 import { useUploadTravelPhotoMutation } from "@/hooks/mutation/useDiaryMutations";
 import { processSingleFile } from "@/lib/processFile";
 import { getDiaryDetail } from "@/services/diaryService";
@@ -239,6 +241,22 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
           }
           return mappedMetadata;
         });
+
+        const newCount = metadataCount + mappedMetadata.length;
+        sendGAEvent("event", "record_photo_add", {
+          flow: "editor",
+          screen: "record_edit",
+          click_code: "editor.record.edit.photo.add",
+          photo_count: newCount,
+        });
+        if (newCount >= MAX_IMAGES) {
+          sendGAEvent("event", "record_photo_limit_reached", {
+            flow: "editor",
+            screen: "record_edit",
+            click_code: "editor.record.edit.photo.add",
+            photo_count: 3,
+          });
+        }
       } catch (error) {
         alert(error instanceof Error ? error.message : "이미지 업로드에 실패했습니다.");
       } finally {

--- a/src/components/nationSelect/NationSelectClient.tsx
+++ b/src/components/nationSelect/NationSelectClient.tsx
@@ -34,6 +34,11 @@ export const NationSelectClient = ({
   const router = useRouter();
   const registeredCityNamesSet = new Set(registeredCityNames);
 
+  const selectedCountRef = useRef(0);
+  useEffect(() => {
+    selectedCountRef.current = selectedCityList.length;
+  }, [selectedCityList]);
+
   const { mutateAsync: createMemberTravels } = useCreateMemberTravelsMutation();
   const { searchResults, isSearching, searchError, searchKeyword, setSearchKeyword, clearSearch, hasSearched } =
     useCitySearch();
@@ -46,11 +51,24 @@ export const NationSelectClient = ({
   const selectedCityIds = new Set(selectedCityList.map(city => city.id));
 
   useEffect(() => {
-    if (mode !== "default") return;
-    sendGAEvent("event", "onboarding_placeselect_view", {
-      flow: "onboarding",
-      screen: "placeselect",
-    });
+    if (mode === "default") {
+      sendGAEvent("event", "onboarding_placeselect_view", {
+        flow: "onboarding",
+        screen: "placeselect",
+      });
+    } else if (mode === "edit-add") {
+      sendGAEvent("event", "editor_placeselect_view", {
+        flow: "editor",
+        screen: "cityadd",
+      });
+      return () => {
+        sendGAEvent("event", "editor_placeselect_exit", {
+          flow: "editor",
+          screen: "cityadd",
+          selected_count: selectedCountRef.current,
+        });
+      };
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -64,10 +82,17 @@ export const NationSelectClient = ({
         click_code: isSearchingMode ? "onboarding.placeselect.search.result.add" : "onboarding.placeselect.popular.add",
         selected_count: selectedCityList.length + 1,
       });
+    } else if (mode === "edit-add") {
+      sendGAEvent("event", "placeselect_city_add", {
+        flow: "editor",
+        screen: "cityadd",
+        click_code: isSearchingMode ? "editor.placeselect.search.result.add" : "editor.placeselect.popular.add",
+        selected_count: selectedCityList.length + 1,
+      });
     }
   };
 
-  const handleRemoveCity = (cityId: string) => {
+  const handleRemoveCity = (cityId: string, source: "list" | "selected" = "list") => {
     setSelectedCityList(prev => prev.filter(city => city.id !== cityId));
     if (mode === "default") {
       sendGAEvent("event", "place_remove", {
@@ -78,6 +103,19 @@ export const NationSelectClient = ({
           : "onboarding.placeselect.popular.remove",
         selected_count: selectedCityList.length - 1,
       });
+    } else if (mode === "edit-add") {
+      const clickCode =
+        source === "selected"
+          ? "editor.placeselect.selected.remove"
+          : isSearchingMode
+            ? "editor.placeselect.search.result.remove"
+            : "editor.placeselect.popular.remove";
+      sendGAEvent("event", "placeselect_city_remove", {
+        flow: "editor",
+        screen: "cityadd",
+        click_code: clickCode,
+        selected_count: selectedCityList.length - 1,
+      });
     }
   };
 
@@ -85,6 +123,12 @@ export const NationSelectClient = ({
     if (selectedCityList.length === 0) return;
 
     if (mode === "edit-add" && onComplete) {
+      sendGAEvent("event", "placeselect_city_add_confirm_click", {
+        flow: "editor",
+        screen: "cityadd",
+        click_code: "editor.placeselect.cta.confirm",
+        selected_count: selectedCityList.length,
+      });
       onComplete(selectedCityList);
       return;
     }
@@ -129,13 +173,21 @@ export const NationSelectClient = ({
       hasTrackedSearch.current = false;
       return;
     }
-    if (hasSearched && !hasTrackedSearch.current && mode === "default") {
+    if (hasSearched && !hasTrackedSearch.current) {
       hasTrackedSearch.current = true;
-      sendGAEvent("event", "place_search", {
-        flow: "onboarding",
-        screen: "placeselect",
-        click_code: "onboarding.placeselect.search.input",
-      });
+      if (mode === "default") {
+        sendGAEvent("event", "place_search", {
+          flow: "onboarding",
+          screen: "placeselect",
+          click_code: "onboarding.placeselect.search.input",
+        });
+      } else if (mode === "edit-add") {
+        sendGAEvent("event", "placeselect_city_search", {
+          flow: "editor",
+          screen: "cityadd",
+          click_code: "editor.placeselect.search.input",
+        });
+      }
     }
   }, [hasSearched, isSearchingMode, mode]);
 
@@ -235,6 +287,7 @@ export const NationSelectClient = ({
           onRemoveCity={handleRemoveCity}
           onCreateGlobe={handleCreateGlobe}
           buttonLabel={buttonLabel}
+          mode={mode}
         />
       </div>
     </main>

--- a/src/components/nationSelect/NationSelectFooter.tsx
+++ b/src/components/nationSelect/NationSelectFooter.tsx
@@ -7,19 +7,20 @@ import { SelectedCities } from "./SelectedCities";
 
 type NationSelectFooterProps = {
   selectedCities: City[];
-  onRemoveCity: (cityId: string) => void;
+  onRemoveCity: (cityId: string, source?: "list" | "selected") => void;
   onCreateGlobe: () => void;
   buttonLabel?: string;
+  mode?: "default" | "edit-add";
 };
 
 export const NationSelectFooter = memo(
-  ({ selectedCities, onRemoveCity, onCreateGlobe, buttonLabel }: NationSelectFooterProps) => {
+  ({ selectedCities, onRemoveCity, onCreateGlobe, buttonLabel, mode }: NationSelectFooterProps) => {
     const isButtonEnabled = selectedCities.length > 0;
 
     return (
       <div className="sticky bottom-0 flex justify-center">
         <div className="bg-surface-thirdly w-full max-w-lg px-4 py-6">
-          <SelectedCities selectedCities={selectedCities} onRemoveCity={onRemoveCity} />
+          <SelectedCities selectedCities={selectedCities} onRemoveCity={onRemoveCity} mode={mode} />
 
           <Button
             variant={isButtonEnabled ? "primary" : "disabled"}

--- a/src/components/nationSelect/SelectedCities.tsx
+++ b/src/components/nationSelect/SelectedCities.tsx
@@ -7,10 +7,11 @@ import type { City } from "@/types/city";
 
 type SelectedCitiesProps = {
   selectedCities: City[];
-  onRemoveCity: (cityId: string) => void;
+  onRemoveCity: (cityId: string, source?: "list" | "selected") => void;
+  mode?: "default" | "edit-add";
 };
 
-export const SelectedCities = ({ selectedCities, onRemoveCity }: SelectedCitiesProps) => {
+export const SelectedCities = ({ selectedCities, onRemoveCity, mode }: SelectedCitiesProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -35,13 +36,17 @@ export const SelectedCities = ({ selectedCities, onRemoveCity }: SelectedCitiesP
             size="md"
             removable
             onRemove={() => {
-              onRemoveCity(id);
-              sendGAEvent("event", "place_remove", {
-                flow: "onboarding",
-                screen: "placeselect",
-                click_code: "onboarding.placeselect.selected.remove",
-                selected_count: selectedCities.length - 1,
-              });
+              if (mode === "edit-add") {
+                onRemoveCity(id, "selected");
+              } else {
+                onRemoveCity(id);
+                sendGAEvent("event", "place_remove", {
+                  flow: "onboarding",
+                  screen: "placeselect",
+                  click_code: "onboarding.placeselect.selected.remove",
+                  selected_count: selectedCities.length - 1,
+                });
+              }
             }}
             className="shrink-0"
           >

--- a/src/components/record/CityList.tsx
+++ b/src/components/record/CityList.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from "next/navigation";
 
+import { sendGAEvent } from "@next/third-parties/google";
+
 import { ICEditIcon } from "@/assets/icons";
 import { COUNTRY_CODE_TO_FLAG } from "@/constants/countryMapping";
 import type { RecordResponse } from "@/types/record";
@@ -31,6 +33,11 @@ export function CityList({ filteredRegions }: CityListProps) {
                 <button
                   type="button"
                   onClick={() => {
+                    sendGAEvent("event", "record_edit_entry_click", {
+                      flow: "editor",
+                      screen: "record",
+                      click_code: "editor.record.city.item.record_entry",
+                    });
                     const cityParam = encodeURIComponent(city.name);
                     const countryParam = encodeURIComponent(region.regionName);
                     router.push(`/image-metadata?cityId=${city.cityId}&country=${countryParam}&city=${cityParam}`);

--- a/src/components/record/ContinentFilter.tsx
+++ b/src/components/record/ContinentFilter.tsx
@@ -1,3 +1,5 @@
+import { sendGAEvent } from "@next/third-parties/google";
+
 import type { Continent } from "@/types/record";
 
 interface ContinentFilterProps {
@@ -23,7 +25,15 @@ export function ContinentFilter({
           <button
             type="button"
             key={continent}
-            onClick={() => onContinentChange(continent)}
+            onClick={() => {
+              sendGAEvent("event", "record_filter_select", {
+                flow: "editor",
+                screen: "record",
+                click_code: "editor.record.filter.item",
+                continent,
+              });
+              onContinentChange(continent);
+            }}
             className={`shrink-0 inline-flex justify-center items-center gap-1 rounded-xl ${
               isSelected
                 ? "px-3.5 py-2 bg-state-enabled"

--- a/src/components/record/EditClient.tsx
+++ b/src/components/record/EditClient.tsx
@@ -204,6 +204,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_delete_trigger", {
       flow: "editor",
       screen: "cityedit",
+      click_code: "editor.placeedit.list.item.remove",
       city_id: cityToRemove?.cityId ?? cityId,
       current_city_count: current.length,
     });
@@ -253,6 +254,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_delete_confirm", {
       flow: "editor",
       screen: "cityedit",
+      click_code: "editor.placeedit.delete.modal.confirm",
       city_id: cityToDelete.cityId ?? confirmId,
       previous_city_count: current.length,
       current_city_count: current.length - 1,
@@ -320,6 +322,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_save_click", {
       flow: "editor",
       screen: "cityedit",
+      click_code: "editor.placeedit.header.save",
       initial_city_count: initialCityCount.current,
       current_city_count: current.length,
     });
@@ -413,6 +416,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_add_entry_click", {
       flow: "editor",
       screen: "cityedit",
+      click_code: "editor.placeedit.add.entry",
       current_city_count: current.length,
     });
 

--- a/src/components/record/EditClient.tsx
+++ b/src/components/record/EditClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+
+import { sendGAEvent } from "@next/third-parties/google";
 
 import { IconExclamationCircleMonoIcon } from "@/assets/icons";
 import {
@@ -53,6 +55,10 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [showCannotDeleteModal, setShowCannotDeleteModal] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+
+  const initialCityCount = useRef(cities.length);
+  const hasSavedRef = useRef(false);
+  const isChangedRef = useRef(false);
   const { mutateAsync: createMemberTravels } = useCreateMemberTravelsMutation();
   const { mutateAsync: deleteMemberTravel } = useDeleteMemberTravelMutation();
 
@@ -130,6 +136,28 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     });
   }, [cities, removedIds]);
 
+  // isChangedRef 동기화
+  useEffect(() => {
+    isChangedRef.current = isChanged;
+  }, [isChanged]);
+
+  // cityedit_view / cityedit_exit
+  useEffect(() => {
+    sendGAEvent("event", "cityedit_view", {
+      flow: "editor",
+      screen: "cityedit",
+    });
+
+    return () => {
+      sendGAEvent("event", "cityedit_exit", {
+        flow: "editor",
+        screen: "cityedit",
+        has_changed: isChangedRef.current,
+        has_saved: hasSavedRef.current,
+      });
+    };
+  }, []);
+
   // 브라우저 뒤로가기 감지
   useEffect(() => {
     const handlePopState = () => {
@@ -172,6 +200,14 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
       return;
     }
 
+    const cityToRemove = current.find(c => c.id === cityId);
+    sendGAEvent("event", "cityedit_delete_trigger", {
+      flow: "editor",
+      screen: "cityedit",
+      city_id: cityToRemove?.cityId ?? cityId,
+      current_city_count: current.length,
+    });
+
     if (isNew) {
       // 새로 추가한 도시 삭제 - current에서 제거하고 URL도 업데이트
       const updatedCurrent = current.filter(c => c.id !== cityId);
@@ -213,6 +249,14 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
 
     const cityToDelete = current.find(c => c.id === confirmId);
     if (!cityToDelete) return;
+
+    sendGAEvent("event", "cityedit_delete_confirm", {
+      flow: "editor",
+      screen: "cityedit",
+      city_id: cityToDelete.cityId ?? confirmId,
+      previous_city_count: current.length,
+      current_city_count: current.length - 1,
+    });
 
     // 삭제된 도시 정보 저장 (저장 시 서버에 전송하기 위해)
     setDeletedCitiesInfo(prev => {
@@ -272,6 +316,14 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
       router.push("/login");
       return;
     }
+
+    sendGAEvent("event", "cityedit_save_click", {
+      flow: "editor",
+      screen: "cityedit",
+      initial_city_count: initialCityCount.current,
+      current_city_count: current.length,
+    });
+    hasSavedRef.current = true;
 
     setIsSaving(true);
     const startTime = Date.now();
@@ -358,6 +410,12 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
   };
 
   const handleAddClick = () => {
+    sendGAEvent("event", "cityedit_add_entry_click", {
+      flow: "editor",
+      screen: "cityedit",
+      current_city_count: current.length,
+    });
+
     // 현재 추가된 도시들(isNew: true)과 삭제된 도시 ID를 쿼리로 전달
     const newCities = current.filter(c => c.isNew);
     const removedParam =

--- a/src/components/record/EditClient.tsx
+++ b/src/components/record/EditClient.tsx
@@ -204,7 +204,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_delete_trigger", {
       flow: "editor",
       screen: "cityedit",
-      click_code: "editor.placeedit.list.item.remove",
+      click_code: "editor.cityedit.list.item.remove",
       city_id: cityToRemove?.cityId ?? cityId,
       current_city_count: current.length,
     });
@@ -254,7 +254,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_delete_confirm", {
       flow: "editor",
       screen: "cityedit",
-      click_code: "editor.placeedit.delete.modal.confirm",
+      click_code: "editor.cityedit.delete.modal.confirm",
       city_id: cityToDelete.cityId ?? confirmId,
       previous_city_count: current.length,
       current_city_count: current.length - 1,
@@ -322,7 +322,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_save_click", {
       flow: "editor",
       screen: "cityedit",
-      click_code: "editor.placeedit.header.save",
+      click_code: "editor.cityedit.header.save",
       initial_city_count: initialCityCount.current,
       current_city_count: current.length,
     });
@@ -416,7 +416,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     sendGAEvent("event", "cityedit_add_entry_click", {
       flow: "editor",
       screen: "cityedit",
-      click_code: "editor.placeedit.add.entry",
+      click_code: "editor.cityedit.add.entry",
       current_city_count: current.length,
     });
 

--- a/src/components/record/EditClient.tsx
+++ b/src/components/record/EditClient.tsx
@@ -326,7 +326,6 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
       initial_city_count: initialCityCount.current,
       current_city_count: current.length,
     });
-    hasSavedRef.current = true;
 
     setIsSaving(true);
     const startTime = Date.now();
@@ -382,6 +381,7 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
         promises.push(addPromise);
       }
       await Promise.all(promises);
+      hasSavedRef.current = true;
 
       console.log(`[Save] 모든 요청 성공`);
 

--- a/src/components/record/EditClient.tsx
+++ b/src/components/record/EditClient.tsx
@@ -136,6 +136,24 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
     });
   }, [cities, removedIds]);
 
+  const baseIds = useMemo(() => new Set(base.map(c => c.id)), [base]);
+  const currentIds = useMemo(() => new Set(current.map(c => c.id)), [current]);
+  const isChanged = useMemo(() => {
+    // 삭제된 도시가 있으면 변경된 것
+    if (removedIds.size > 0) return true;
+
+    // 추가된 도시가 있으면 변경된 것
+    if (current.some(c => c.isNew)) return true;
+
+    // 개수나 ID가 다르면 변경된 것
+    if (current.length !== base.length) return true;
+    if (baseIds.size !== currentIds.size) return true;
+    for (const id of baseIds) {
+      if (!currentIds.has(id)) return true;
+    }
+    return false;
+  }, [base.length, baseIds, current, currentIds, removedIds.size]);
+
   // isChangedRef 동기화
   useEffect(() => {
     isChangedRef.current = isChanged;
@@ -174,24 +192,6 @@ export function EditClient({ cities, deletedCities = [] }: EditClientProps) {
   const handleBack = () => {
     router.push("/record");
   };
-
-  const baseIds = useMemo(() => new Set(base.map(c => c.id)), [base]);
-  const currentIds = useMemo(() => new Set(current.map(c => c.id)), [current]);
-  const isChanged = useMemo(() => {
-    // 삭제된 도시가 있으면 변경된 것
-    if (removedIds.size > 0) return true;
-
-    // 추가된 도시가 있으면 변경된 것
-    if (current.some(c => c.isNew)) return true;
-
-    // 개수나 ID가 다르면 변경된 것
-    if (current.length !== base.length) return true;
-    if (baseIds.size !== currentIds.size) return true;
-    for (const id of baseIds) {
-      if (!currentIds.has(id)) return true;
-    }
-    return false;
-  }, [base.length, baseIds, current, currentIds, removedIds.size]);
 
   const handleRemove = (cityId: string, isNew?: boolean) => {
     // 마지막 1개 남은 도시를 삭제하려고 하는 경우

--- a/src/components/record/RecordClient.tsx
+++ b/src/components/record/RecordClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+
+import { sendGAEvent } from "@next/third-parties/google";
 
 import { Header } from "@/components/common/Header";
 import type { Continent, RecordResponse } from "@/types/record";
@@ -16,6 +18,25 @@ interface RecordClientProps {
 export function RecordClient({ initialData }: RecordClientProps) {
   const router = useRouter();
   const [selectedContinent, setSelectedContinent] = useState<Continent>("전체");
+  const hasViewedRef = useRef(false);
+
+  // editor_record_view / editor_record_exit
+  useEffect(() => {
+    hasViewedRef.current = true;
+    sendGAEvent("event", "editor_record_view", {
+      flow: "editor",
+      screen: "record",
+    });
+
+    return () => {
+      if (hasViewedRef.current) {
+        sendGAEvent("event", "editor_record_exit", {
+          flow: "editor",
+          screen: "record",
+        });
+      }
+    };
+  }, []);
 
   // 브라우저 뒤로가기 감지
   useEffect(() => {
@@ -41,6 +62,11 @@ export function RecordClient({ initialData }: RecordClientProps) {
   };
 
   const handleEditClick = () => {
+    sendGAEvent("event", "record_city_manage_entry", {
+      flow: "editor",
+      screen: "record",
+      click_code: "editor.record.header.city_edit",
+    });
     router.push("/record/edit");
   };
 

--- a/src/services/diaryService.ts
+++ b/src/services/diaryService.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, apiPost, apiPut } from "@/lib/apiClient";
+import { apiDelete, ApiError, apiGet, apiPost, apiPut } from "@/lib/apiClient";
 import type {
   CreateDiaryParams,
   CreateDiaryPhotoParams,
@@ -211,6 +211,7 @@ export const getDiaryDetail = async (diaryId: string | number, token?: string): 
     return response.data;
   } catch (error) {
     logger.error("[getDiaryDetail] 실패:", error);
+    if (error instanceof ApiError) throw error;
     throw new Error("여행 기록을 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.");
   }
 };
@@ -303,6 +304,7 @@ export const deleteDiaryPhoto = async (diaryId: string | number, photoId: number
     await apiDelete(`/api/v1/diaries/photo/${diaryId}/${photoId}`, undefined, authToken);
   } catch (error) {
     logger.error("[deleteDiaryPhoto] 실패:", error);
+    if (error instanceof ApiError) throw error;
     throw new Error("여행 기록 사진 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.");
   }
 };
@@ -340,6 +342,7 @@ export const addDiaryPhoto = async (
     return response.data;
   } catch (error) {
     logger.error("[addDiaryPhoto] 실패:", error);
+    if (error instanceof ApiError) throw error;
     throw new Error("여행 기록 사진 추가에 실패했습니다. 잠시 후 다시 시도해주세요.");
   }
 };
@@ -407,6 +410,7 @@ export const updateDiary = async (
     await apiPut(`/api/v1/diaries/${diaryId}`, params, authToken);
   } catch (error) {
     logger.error("[updateDiary] 실패:", error);
+    if (error instanceof ApiError) throw error;
     throw new Error("여행 기록 수정에 실패했습니다. 잠시 후 다시 시도해주세요.");
   }
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

  [GLB-55](https://globber-app.atlassian.net/browse/GLB-55)

  ## 📝작업 내용

  ## 📍 개요 (Summary)
  - 에디터 플로우 전반(기록하기 → 도시 편집 → 도시 추가 → 기록 작성 → 날짜/위치/비율 편집 → 저장)에 걸쳐 Google Analytics 이벤트를 적용했습니다.

  ## 🛠️ 작업 내용 (Changes)

  1. **기록하기 화면 (`RecordClient`, `ContinentFilter`, `CityList`)**
     - `editor_record_view` / `editor_record_exit` (진입·이탈)
     - `record_filter_select` (대륙 필터 선택)
     - `record_edit_entry_click` (도시 기록 진입)
     - `record_city_manage_entry` (도시 관리 진입)

  2. **도시 편집 화면 (`EditClient`)**
     - `cityedit_view` / `cityedit_exit`
     - `cityedit_add_entry_click`, `cityedit_delete_trigger`, `cityedit_delete_confirm`, `cityedit_save_click`

  3. **도시 추가 화면 (`NationSelectClient`, `NationSelectFooter`, `SelectedCities`)**
     - `editor_placeselect_view` / `editor_placeselect_exit`
     - `placeselect_city_add` (검색/인기 도시 구분), `placeselect_city_remove` (리스트/선택칩 source 구분)
     - `placeselect_city_search`, `placeselect_city_add_confirm_click`

  4. **기록 작성 화면 (`ImageMetadata`, `useImageMetadata`)**
     - `editor_record_edit_view` / `editor_record_edit_exit`
     - `record_photo_add`, `record_photo_limit_reached`, `record_photo_delete_confirm`
     - `record_edit_save_click`
     - `record_text_progress` (50/100/150/200자 마일스톤)
     - `record_tag_select`, `record_photo_ratio_entry`
     - `record_meta_date_change`, `record_meta_location_change` (add/update/remove)

  5. **날짜 입력 화면 (`DateSelectBottomSheet`)**
     - `record_meta_date_view`, `record_meta_date_input_change`, `record_meta_date_confirm`

  6. **위치 입력 화면 (`LocationSelectBottomSheet`)**
     - `record_meta_location_view`, `record_meta_location_search`, `record_meta_location_confirm`

  7. **비율 편집 화면 (`ImageCropModal`)**
     - `record_crop_view`, `record_crop_interaction` (drag/zoom), `record_crop_complete`, `record_crop_exit`

  8. **저장 로딩 화면 (`useDiaryAction`)**
     - `record_save_start`, `record_save_complete`, `record_save_fail`, `record_save_exit`

  ## 💬리뷰 요구사항(선택)

  - 이탈 이벤트(`exit`)는 `useEffect` cleanup에서 `useRef`로 최신값을 참조하는 패턴으로 구현했습니다.
  - `record_save_exit`는 저장 API 호출 중 강제 이탈 시에만 발생하도록 `saveStartedRef` / `saveCompletedRef`로 구분했습니다.

  [GLB-55]: https://globber-app.atlassian.net/browse/GLB-55

[GLB-55]: https://globber-app.atlassian.net/browse/GLB-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GLB-55]: https://globber-app.atlassian.net/browse/GLB-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  - 사진 메타데이터 편집, 텍스트 입력, 지역 선택 등 사용자 상호작용에 대한 분석 추적 강화
  - 저장 작업 및 결과에 대한 모니터링 개선
  - 앱 사용 패턴 데이터 수집 확대를 통한 향후 기능 개선 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->