### PR TITLE
fix: push 시 autoFit 이후 줌 아웃할 때 DEFAULT 7로 급격히 스냅되는 버그 수정

### DIFF
--- a/src/lib/globe/eventHandlers.ts
+++ b/src/lib/globe/eventHandlers.ts
@@ -63,8 +63,6 @@ export const createClusterTransitionHandler = (
         expandedContinentCountryIds: countryIds,
       }));
 
-      setZoomStack(prev => [...prev, currentZoomRef.current]);
-
       return items;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

[GLB-66](https://globber-app.atlassian.net/browse/GLB-66)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- push 시 autoFit 이후 줌 아웃할 때 DEFAULT 7로 급격히 스냅되는 버그 발생
- 대륙 클러스터는 drill-down 상태가 아니므로 zoomStack에 push하지 않도록 설정하여 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[GLB-66]: https://globber-app.atlassian.net/browse/GLB-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 대륙 클러스터에서 국가로 전환할 때 줌 네비게이션 동작 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->