### PR TITLE
[GLB-63] 사진 드래그앤드롭 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@googlemaps/google-maps-services-js": "^3.4.2",
     "@hookform/resolvers": "^5.2.2",
     "@next/third-parties": "^16.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.3)
       '@googlemaps/google-maps-services-js':
         specifier: ^3.4.2
         version: 3.4.2
@@ -756,6 +765,28 @@ packages:
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -5970,6 +6001,31 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@dimforge/rapier3d-compat@0.12.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
 
   '@emnapi/core@1.8.1':
     dependencies:

--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -153,7 +153,11 @@ export const ImageCarousel = ({
   return (
     <div className="relative select-none w-[251px] mx-auto">
       <div className="overflow-hidden rounded-xl border border-white/20" style={{ aspectRatio: "9 / 16" }}>
-        <div className="w-full h-full bg-black relative overflow-hidden" aria-label="이미지 미리보기">
+        <div
+          className="w-full h-full bg-black relative overflow-hidden"
+          aria-label="이미지 미리보기"
+          onClick={() => setIsCropModalOpen(true)}
+        >
           <Image
             src={currentImage}
             alt={shown.fileName}

--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -153,20 +153,22 @@ export const ImageCarousel = ({
   return (
     <div className="relative select-none w-[251px] mx-auto">
       <div className="overflow-hidden rounded-xl border border-white/20" style={{ aspectRatio: "9 / 16" }}>
-        <button
-          type="button"
-          className="w-full h-full bg-black relative cursor-pointer overflow-hidden"
-          onClick={() => setIsCropModalOpen(true)}
-          aria-label="이미지 편집"
-          disabled={isCropUploading}
-        >
-          <Image src={currentImage} alt={shown.fileName} fill sizes="251px" className="object-cover" unoptimized />
+        <div className="w-full h-full bg-black relative overflow-hidden" aria-label="이미지 미리보기">
+          <Image
+            src={currentImage}
+            alt={shown.fileName}
+            fill
+            sizes="251px"
+            className="object-cover"
+            unoptimized
+            draggable={false}
+          />
           {isCropUploading && (
             <div className="absolute inset-0 bg-black/60 flex items-center justify-center">
               <div className="text-white text-sm">업로드 중...</div>
             </div>
           )}
-        </button>
+        </div>
       </div>
       <div className="absolute top-3 left-3">
         <TagSelector selectedTag={selectedTag} onSelect={handleTagSelect} onRemove={handleTagRemove} />

--- a/src/components/imageMetadata/ImageCropModal.tsx
+++ b/src/components/imageMetadata/ImageCropModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import type { Area } from "react-easy-crop";
 import Cropper from "react-easy-crop";
 
@@ -64,16 +65,23 @@ export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) 
     }
   };
 
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   if (!imageBlobUrl) {
-    return (
-      <div className="image-crop-modal fixed inset-0 z-50 bg-black flex items-center justify-center">
+    if (!mounted) return null;
+    return createPortal(
+      <div className="image-crop-modal fixed inset-0 z-[100] bg-black flex items-center justify-center">
         <div className="text-white text-sm">이미지 로딩 중...</div>
-      </div>
+      </div>,
+      document.body
     );
   }
 
-  return (
-    <div className="image-crop-modal fixed inset-0 z-50 bg-black">
+  if (!mounted) return null;
+
+  return createPortal(
+    <div className="image-crop-modal fixed inset-0 z-[100] bg-black">
       <div className="max-w-md mx-auto w-full h-full relative">
         {/* Header - Absolute positioned */}
         <div className="absolute top-0 left-0 right-0 z-10">
@@ -88,7 +96,7 @@ export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) 
         </div>
 
         {/* Crop Area - Full screen */}
-        <div className="relative w-full h-full">
+        <div className="relative w-full h-full pb-[env(safe-area-inset-bottom)]">
           <Cropper
             image={imageBlobUrl}
             crop={crop}
@@ -107,7 +115,8 @@ export const ImageCropModal = ({ image, onClose, onSave }: ImageCropModalProps) 
           />
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/src/components/imageMetadata/ImageCropModal.tsx
+++ b/src/components/imageMetadata/ImageCropModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Area } from "react-easy-crop";
 import Cropper from "react-easy-crop";
@@ -171,7 +171,7 @@ export const ImageCropModal = ({ image, onClose, onSave, photoIndex = 0 }: Image
           <Header
             variant="dark"
             leftIcon="close"
-            onLeftClick={handleClose}
+            onLeftClick={onClose}
             rightButtonTitle="완료"
             rightButtonVariant="white"
             onRightClick={createCroppedImage}

--- a/src/components/imageMetadata/ImageCropModal.tsx
+++ b/src/components/imageMetadata/ImageCropModal.tsx
@@ -75,6 +75,8 @@ export const ImageCropModal = ({ image, onClose, onSave, photoIndex = 0 }: Image
         URL.revokeObjectURL(blobUrlToCleanup);
       }
     };
+    // 부모 컴포넌트 렌더링 시 onClose 참조값이 변경되어 이펙트가 무의미하게 재실행되고,
+    // 이로 인해 만들어둔 프리뷰용 Blob URL이 조기 해제(cleanup)되는 버그를 방지하기 위해 의존성 배열에서 제외합니다.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [image]);
 

--- a/src/components/imageMetadata/ImageCropModal.tsx
+++ b/src/components/imageMetadata/ImageCropModal.tsx
@@ -75,7 +75,8 @@ export const ImageCropModal = ({ image, onClose, onSave, photoIndex = 0 }: Image
         URL.revokeObjectURL(blobUrlToCleanup);
       }
     };
-  }, [image, onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [image]);
 
   const handleGestureActivity = (isZoom: boolean) => {
     const now = Date.now();
@@ -211,10 +212,19 @@ export const ImageCropModal = ({ image, onClose, onSave, photoIndex = 0 }: Image
  */
 const fetchImageAsBlob = async (url: string): Promise<string> => {
   try {
-    const response = await fetch(url, {
+    // S3 등 외부 요소를 fetch할 때 브라우저 디스크 캐시(<img> 태그가 로드한 CORS 헤더 없는 캐시)를
+    // 사용할 경우 CORS 에러가 발생할 수 있으므로, 캐시 우회를 위해 파라미터를 추가합니다.
+    // 단, URL이 이미 브라우저 내부의 blob: 형태인 경우 파라미터를 추가하면 깨지므로 분기 처리합니다.
+    let fetchUrl = url;
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      const cacheUrl = new URL(url);
+      cacheUrl.searchParams.set("t", Date.now().toString());
+      fetchUrl = cacheUrl.toString();
+    }
+
+    const response = await fetch(fetchUrl, {
       mode: "cors",
       credentials: "include",
-      cache: "force-cache",
     });
 
     if (response.ok) {
@@ -226,8 +236,8 @@ const fetchImageAsBlob = async (url: string): Promise<string> => {
     console.warn("Direct S3 fetch failed, falling back to Next.js proxy:", error);
   }
 
-  // Fallback: Next.js Image Proxy 사용
-  const proxyUrl = `/_next/image?url=${encodeURIComponent(url)}&w=3840&q=95`;
+  // Fallback: Next.js Image Proxy 사용 (3840은 부하가 커 1920으로 낮춤)
+  const proxyUrl = `/_next/image?url=${encodeURIComponent(url)}&w=1920&q=95`;
   const proxyResponse = await fetch(proxyUrl);
 
   if (!proxyResponse.ok) {

--- a/src/components/imageMetadata/ImageMetadata.tsx
+++ b/src/components/imageMetadata/ImageMetadata.tsx
@@ -47,6 +47,7 @@ export const ImageMetadataComponent = ({
     handleTagChange,
     handleDateChange,
     handleLocationChange,
+    handleReorder,
   } = useImageMetadata({ diaryId, isEditMode });
 
   const { handleSave } = useDiaryAction({
@@ -99,6 +100,7 @@ export const ImageMetadataComponent = ({
         handleTagChange={handleTagChange}
         handleDateChange={handleDateChange}
         handleLocationChange={handleLocationChange}
+        handleReorder={handleReorder}
       />
 
       <input

--- a/src/components/imageMetadata/ImageUploadSection.tsx
+++ b/src/components/imageMetadata/ImageUploadSection.tsx
@@ -9,8 +9,7 @@ import {
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
-  MouseSensor,
-  TouchSensor,
+  PointerSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -51,6 +50,7 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
     transition,
     opacity: isDragging ? 0 : 1, // Hide original item completely so DragOverlay is the only one visible
     zIndex: isDragging ? 0 : 1,
+    touchAction: "none" as const,
   };
 
   return (
@@ -70,6 +70,18 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
       onPointerCancel={e => {
         onPressEnd();
         listeners?.onPointerCancel?.(e);
+      }}
+      onTouchStart={e => {
+        onPressStart();
+        listeners?.onTouchStart?.(e);
+      }}
+      onTouchEnd={e => {
+        onPressEnd();
+        listeners?.onTouchEnd?.(e);
+      }}
+      onTouchCancel={e => {
+        onPressEnd();
+        listeners?.onTouchCancel?.(e);
       }}
       className="shrink-0 outline-none select-none relative"
     >
@@ -109,15 +121,9 @@ export const ImageUploadSection = ({
   const [pressingId, setPressingId] = useState<string | null>(null);
 
   const sensors = useSensors(
-    useSensor(MouseSensor, {
+    useSensor(PointerSensor, {
       activationConstraint: {
-        distance: 10,
-      },
-    }),
-    useSensor(TouchSensor, {
-      activationConstraint: {
-        delay: 1000,
-        tolerance: 15,
+        distance: 6,
       },
     })
   );
@@ -156,7 +162,7 @@ export const ImageUploadSection = ({
   const renderContent = () => (
     <div
       className="flex gap-4 overflow-x-auto px-4 pb-6 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
-      style={{ touchAction: "pan-x", minHeight: hasImages ? undefined : "460px" }}
+      style={{ touchAction: isDndEnabled ? "pan-y" : "pan-x", minHeight: hasImages ? undefined : "460px" }}
     >
       {!hasImages && (
         <div className="shrink-0">

--- a/src/components/imageMetadata/ImageUploadSection.tsx
+++ b/src/components/imageMetadata/ImageUploadSection.tsx
@@ -1,5 +1,21 @@
 "use client";
 
+import { useState } from "react";
+
+import {
+  closestCenter,
+  defaultDropAnimationSideEffects,
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { horizontalListSortingStrategy, SortableContext, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { PlusIcon } from "lucide-react";
 
 import type { ImageTag } from "@/types/imageMetadata";
@@ -16,7 +32,63 @@ interface ImageUploadSectionProps {
   handleTagChange: (id: string, tag: ImageTag | null) => void;
   handleDateChange: (id: string, date: string | null) => void;
   handleLocationChange: (id: string, location: LocationSelection | null) => void;
+  handleReorder?: (oldIndex: number, newIndex: number) => void;
 }
+
+interface SortableImageCardProps {
+  id: string;
+  isPressing: boolean;
+  onPressStart: () => void;
+  onPressEnd: () => void;
+  children: React.ReactNode;
+}
+
+const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children }: SortableImageCardProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0 : 1, // Hide original item completely so DragOverlay is the only one visible
+    zIndex: isDragging ? 0 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onPointerDown={e => {
+        onPressStart();
+        listeners?.onPointerDown?.(e);
+      }}
+      onPointerUp={e => {
+        onPressEnd();
+        listeners?.onPointerUp?.(e);
+      }}
+      onPointerCancel={e => {
+        onPressEnd();
+        listeners?.onPointerCancel?.(e);
+      }}
+      className="shrink-0 outline-none select-none relative"
+    >
+      <div
+        style={{
+          transform: isPressing && !isDragging ? "scale(0.96)" : "scale(1)",
+          transition: "transform 0.2s ease, filter 0.2s ease",
+          borderRadius: "0.75rem", // match xl
+        }}
+        className="relative origin-center"
+      >
+        {isPressing && !isDragging && (
+          <div className="absolute inset-0 bg-black/40 rounded-xl z-20 pointer-events-none" />
+        )}
+        {children}
+      </div>
+    </div>
+  );
+};
 
 export const ImageUploadSection = ({
   metadataList,
@@ -26,17 +98,62 @@ export const ImageUploadSection = ({
   handleTagChange,
   handleDateChange,
   handleLocationChange,
+  handleReorder,
 }: ImageUploadSectionProps) => {
   const hasImages = metadataList.length > 0;
   const MAX_IMAGES = 3;
   const metadataCount = metadataList.length;
   const placeholderCount = Math.max(0, MAX_IMAGES - metadataCount - (hasImages ? 0 : 1));
 
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [pressingId, setPressingId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 10,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 1000,
+        tolerance: 15,
+      },
+    })
+  );
+
   const triggerFileInput = () => {
     document.getElementById(fileUploadId)?.click();
   };
 
-  return (
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+    setPressingId(null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveId(null);
+    setPressingId(null);
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = metadataList.findIndex(item => item.id === active.id);
+      const newIndex = metadataList.findIndex(item => item.id === over.id);
+      if (handleReorder) {
+        handleReorder(oldIndex, newIndex);
+      }
+    }
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+    setPressingId(null);
+  };
+
+  const activeMetadata = metadataList.find(m => m.id === activeId);
+  const isDndEnabled = metadataList.length > 1;
+
+  const renderContent = () => (
     <div
       className="flex gap-4 overflow-x-auto px-4 pb-6 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
       style={{ touchAction: "pan-x", minHeight: hasImages ? undefined : "460px" }}
@@ -62,18 +179,45 @@ export const ImageUploadSection = ({
           </button>
         </div>
       )}
-      {metadataList.map(metadata => (
-        <div key={metadata.id} className="shrink-0">
-          <ImageCarousel
-            image={metadata}
-            onRemove={handleRemove}
-            onImageUpdate={handleImageUpdate}
-            onTagChange={tag => handleTagChange(metadata.id, tag)}
-            onDateChange={yearMonth => handleDateChange(metadata.id, yearMonth)}
-            onLocationChange={location => handleLocationChange(metadata.id, location)}
-          />
-        </div>
-      ))}
+
+      {isDndEnabled ? (
+        <SortableContext items={metadataList.map(m => m.id)} strategy={horizontalListSortingStrategy}>
+          {metadataList.map(metadata => (
+            <SortableImageCard
+              key={metadata.id}
+              id={metadata.id}
+              isPressing={pressingId === metadata.id}
+              onPressStart={() => setPressingId(metadata.id)}
+              onPressEnd={() => {
+                if (pressingId === metadata.id) setPressingId(null);
+              }}
+            >
+              <ImageCarousel
+                image={metadata}
+                onRemove={handleRemove}
+                onImageUpdate={handleImageUpdate}
+                onTagChange={tag => handleTagChange(metadata.id, tag)}
+                onDateChange={yearMonth => handleDateChange(metadata.id, yearMonth)}
+                onLocationChange={location => handleLocationChange(metadata.id, location)}
+              />
+            </SortableImageCard>
+          ))}
+        </SortableContext>
+      ) : (
+        metadataList.map(metadata => (
+          <div key={metadata.id} className="shrink-0">
+            <ImageCarousel
+              image={metadata}
+              onRemove={handleRemove}
+              onImageUpdate={handleImageUpdate}
+              onTagChange={tag => handleTagChange(metadata.id, tag)}
+              onDateChange={yearMonth => handleDateChange(metadata.id, yearMonth)}
+              onLocationChange={location => handleLocationChange(metadata.id, location)}
+            />
+          </div>
+        ))
+      )}
+
       {Array.from({ length: placeholderCount }).map((_, index) => (
         <div key={`empty-${index}`} className="shrink-0">
           <button
@@ -91,5 +235,56 @@ export const ImageUploadSection = ({
         </div>
       ))}
     </div>
+  );
+
+  return (
+    <>
+      {isDndEnabled ? (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          {renderContent()}
+          <DragOverlay
+            dropAnimation={{
+              sideEffects: defaultDropAnimationSideEffects({
+                styles: {
+                  active: {
+                    opacity: "1",
+                  },
+                },
+              }),
+            }}
+          >
+            {activeMetadata ? (
+              <div
+                style={{
+                  transform: "scale(1.08) rotate(-2deg)",
+                  transformOrigin: "center center",
+                  transition: "none", // dnd-kit will handle overlay transition if needed, but we keep it static while moving
+                }}
+                className="shrink-0 relative outline-none select-none"
+              >
+                <div className="absolute inset-0 border-2 border-[#0097C1] rounded-xl z-20 pointer-events-none" />
+                <ImageCarousel
+                  image={activeMetadata}
+                  // pass empty handlers or actual handlers for overlay visual completeness
+                  onRemove={() => {}}
+                  onImageUpdate={handleImageUpdate}
+                  onTagChange={() => {}}
+                  onDateChange={() => {}}
+                  onLocationChange={() => {}}
+                />
+              </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      ) : (
+        renderContent()
+      )}
+    </>
   );
 };

--- a/src/components/imageMetadata/hooks/useDiaryAction.ts
+++ b/src/components/imageMetadata/hooks/useDiaryAction.ts
@@ -154,8 +154,12 @@ export const useDiaryAction = ({
       let currentMetadataList = metadataList;
 
       if (isEditMode && typeof diaryId === "number") {
-        for (const photoId of pendingDeletePhotoIds) {
-          await deleteDiaryPhoto({ diaryId, photoId });
+        if (pendingDeletePhotoIds.length > 0) {
+          for (const photoId of pendingDeletePhotoIds) {
+            await deleteDiaryPhoto({ diaryId, photoId });
+          }
+          // [Workaround] DB 복제 지연(Replication lag) 등을 고려하여 삭제 후 조금 더 기다림
+          await new Promise(r => setTimeout(r, 800));
         }
 
         const withoutPhotoId = metadataList.filter(item => item.photoId == null);
@@ -167,13 +171,6 @@ export const useDiaryAction = ({
             const payload = await buildPhotoPayload(metadata, fallbackMonth, 1);
 
             const createdPhoto = await addDiaryPhoto({ diaryId, photo: payload });
-
-            if (metadata.originalPhotoId) {
-              await deleteDiaryPhoto({
-                diaryId,
-                photoId: metadata.originalPhotoId,
-              });
-            }
             let resolvedPhotoId = createdPhoto.photoId;
 
             if (!resolvedPhotoId) {

--- a/src/components/imageMetadata/hooks/useDiaryAction.ts
+++ b/src/components/imageMetadata/hooks/useDiaryAction.ts
@@ -207,10 +207,21 @@ export const useDiaryAction = ({
         photos,
       };
 
+      let finalDiaryId = diaryId;
       if (isEditMode && typeof diaryId === "number") {
         await updateDiary({ diaryId, params: payload });
       } else {
-        await createDiary({ params: payload });
+        finalDiaryId = await createDiary({ params: payload });
+      }
+
+      if (typeof finalDiaryId === "number") {
+        const orderMapping: Record<string, number> = {};
+        sortedMetadataList.forEach((item, index) => {
+          if (item.photoCode) {
+            orderMapping[item.photoCode] = index;
+          }
+        });
+        sessionStorage.setItem(`diary-${finalDiaryId}-photo-order`, JSON.stringify(orderMapping));
       }
 
       const finalUuid = uuid || getAuthInfo().uuid;

--- a/src/components/imageMetadata/hooks/useImageMetadata.ts
+++ b/src/components/imageMetadata/hooks/useImageMetadata.ts
@@ -292,6 +292,10 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
       const baseUrl = process.env.NEXT_PUBLIC_S3_BASE_URL || "https://globber-dev.s3.ap-northeast-2.amazonaws.com/";
       const newImageUrl = `${baseUrl}${newPhotoCode}`;
 
+      if (targetMetadata.photoId && isEditMode) {
+        setPendingDeletePhotoIds(prev => [...prev, targetMetadata.photoId!]);
+      }
+
       setMetadataList(prev =>
         prev.map(item =>
           item.id === id
@@ -299,7 +303,7 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
                 ...item,
                 imagePreview: newImageUrl,
                 photoCode: newPhotoCode,
-                originalPhotoId: item.photoId,
+                originalPhotoId: undefined, // pendingDeletePhotoIds가 처리하므로 undefined
                 photoId: undefined,
                 isExisting: false,
                 originalImageUrl: item.originalImageUrl || item.imagePreview,

--- a/src/components/imageMetadata/hooks/useImageMetadata.ts
+++ b/src/components/imageMetadata/hooks/useImageMetadata.ts
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useId, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { arrayMove } from "@dnd-kit/sortable";
+
 import { useUploadTravelPhotoMutation } from "@/hooks/mutation/useDiaryMutations";
 import { processSingleFile } from "@/lib/processFile";
 import { getDiaryDetail } from "@/services/diaryService";
@@ -339,6 +341,16 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
     );
   };
 
+  const handleReorder = useCallback((oldIndex: number, newIndex: number) => {
+    setMetadataList(items => {
+      const reordered = arrayMove(items, oldIndex, newIndex);
+      return reordered.map((item, index) => ({
+        ...item,
+        originalIndex: index,
+      }));
+    });
+  }, []);
+
   return {
     metadataList,
     setMetadataList,
@@ -356,5 +368,6 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
     handleTagChange,
     handleDateChange,
     handleLocationChange,
+    handleReorder,
   };
 };

--- a/src/components/record/RecordDetailClient.tsx
+++ b/src/components/record/RecordDetailClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect,useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { HeadlessToastProvider } from "@/components/common/Toast";
@@ -45,7 +45,71 @@ const RecordDetailClient = ({
   initialScrollIndex,
 }: RecordDetailClientProps) => {
   const router = useRouter();
-  const [countryRecords] = useState<RecordData[]>(initialRecords);
+  const [countryRecords, setCountryRecords] = useState<RecordData[]>(initialRecords);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    let hasChanges = false;
+    const reorderedRecords = initialRecords.map(record => {
+      const savedOrder = sessionStorage.getItem(`diary-${record.id}-photo-order`);
+      if (savedOrder) {
+        try {
+          const orderMapping = JSON.parse(savedOrder) as Record<string, number>;
+          const baseUrl = process.env.NEXT_PUBLIC_S3_BASE_URL || "https://globber-dev.s3.ap-northeast-2.amazonaws.com/";
+
+          const newImages = [...record.images].sort((a, b) => {
+            const codeA = a.replace(baseUrl, "");
+            const codeB = b.replace(baseUrl, "");
+            const indexA = orderMapping[codeA] ?? Number.MAX_SAFE_INTEGER;
+            const indexB = orderMapping[codeB] ?? Number.MAX_SAFE_INTEGER;
+            if (indexA !== Number.MAX_SAFE_INTEGER && indexB !== Number.MAX_SAFE_INTEGER) {
+              return indexA - indexB;
+            }
+            // fallback keeping existing relative order
+            const origA = record.images.indexOf(a);
+            const origB = record.images.indexOf(b);
+            const fallbackA = indexA === Number.MAX_SAFE_INTEGER && indexB !== Number.MAX_SAFE_INTEGER ? 1 : 0;
+            const fallbackB = indexB === Number.MAX_SAFE_INTEGER && indexA !== Number.MAX_SAFE_INTEGER ? -1 : 0;
+            if (fallbackA !== 0 || fallbackB !== 0) return fallbackA || fallbackB;
+            return origA - origB;
+          });
+
+          const newMetadata = record.imageMetadata
+            ? [...record.imageMetadata].sort((a, b) => {
+                const codeA = a.url.replace(baseUrl, "");
+                const codeB = b.url.replace(baseUrl, "");
+                const indexA = orderMapping[codeA] ?? Number.MAX_SAFE_INTEGER;
+                const indexB = orderMapping[codeB] ?? Number.MAX_SAFE_INTEGER;
+                if (indexA !== Number.MAX_SAFE_INTEGER && indexB !== Number.MAX_SAFE_INTEGER) {
+                  return indexA - indexB;
+                }
+                const origA = record.imageMetadata!.indexOf(a);
+                const origB = record.imageMetadata!.indexOf(b);
+                const fallbackA = indexA === Number.MAX_SAFE_INTEGER && indexB !== Number.MAX_SAFE_INTEGER ? 1 : 0;
+                const fallbackB = indexB === Number.MAX_SAFE_INTEGER && indexA !== Number.MAX_SAFE_INTEGER ? -1 : 0;
+                if (fallbackA !== 0 || fallbackB !== 0) return fallbackA || fallbackB;
+                return origA - origB;
+              })
+            : undefined;
+
+          // Check if order changed
+          const isChanged = newImages.some((img, idx) => img !== record.images[idx]);
+          if (isChanged) {
+            hasChanges = true;
+            return { ...record, images: newImages, imageMetadata: newMetadata };
+          }
+        } catch (e) {
+          return record;
+        }
+      }
+      return record;
+    });
+
+    if (hasChanges) {
+      setCountryRecords(reorderedRecords);
+    }
+  }, [initialRecords]);
   const [hasShownScrollHint, setHasShownScrollHint] = useState(true);
   const { mutateAsync: deleteDiary } = useDeleteDiaryMutation();
 

--- a/src/components/record/RecordDetailClient.tsx
+++ b/src/components/record/RecordDetailClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect,useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { HeadlessToastProvider } from "@/components/common/Toast";
@@ -50,7 +50,6 @@ const RecordDetailClient = ({
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    let hasChanges = false;
     const reorderedRecords = initialRecords.map(record => {
       const savedOrder = sessionStorage.getItem(`diary-${record.id}-photo-order`);
       if (savedOrder) {
@@ -96,7 +95,6 @@ const RecordDetailClient = ({
           // Check if order changed
           const isChanged = newImages.some((img, idx) => img !== record.images[idx]);
           if (isChanged) {
-            hasChanges = true;
             return { ...record, images: newImages, imageMetadata: newMetadata };
           }
         } catch (e) {
@@ -105,10 +103,7 @@ const RecordDetailClient = ({
       }
       return record;
     });
-
-    if (hasChanges) {
-      setCountryRecords(reorderedRecords);
-    }
+    setCountryRecords(reorderedRecords);
   }, [initialRecords]);
   const [hasShownScrollHint, setHasShownScrollHint] = useState(true);
   const { mutateAsync: deleteDiary } = useDeleteDiaryMutation();

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -140,7 +140,11 @@ export const apiPost = async <T>(endpoint: string, data?: unknown, token?: strin
       const responseText = await response.text().catch(() => "Unable to read response");
       logger.log(`[API] Error response body:`, responseText);
 
-      throw new ApiError(`HTTP error! status: ${response.status}`, response.status, endpoint);
+      let errorMessage = `HTTP error! status: ${response.status}`;
+      if (responseText) {
+        errorMessage += ` - ${responseText}`;
+      }
+      throw new ApiError(errorMessage, response.status, endpoint);
     }
 
     const result = await parseJsonSafely<T>(response);
@@ -183,7 +187,11 @@ export const apiPostWithHeaders = async <T>(
       const responseText = await response.text().catch(() => "Unable to read response");
       logger.log(`[API] Error response body:`, responseText);
 
-      throw new ApiError(`HTTP error! status: ${response.status}`, response.status, endpoint);
+      let errorMessage = `HTTP error! status: ${response.status}`;
+      if (responseText) {
+        errorMessage += ` - ${responseText}`;
+      }
+      throw new ApiError(errorMessage, response.status, endpoint);
     }
 
     const result = await parseJsonSafely<T>(response);
@@ -252,7 +260,11 @@ export const apiPatch = async <T>(endpoint: string, data?: unknown, token?: stri
       const responseText = await response.text().catch(() => "Unable to read response");
       logger.log(`[API] Error response body:`, responseText);
 
-      throw new ApiError(`HTTP error! status: ${response.status}`, response.status, endpoint);
+      let errorMessage = `HTTP error! status: ${response.status}`;
+      if (responseText) {
+        errorMessage += ` - ${responseText}`;
+      }
+      throw new ApiError(errorMessage, response.status, endpoint);
     }
 
     const result = await parseJsonSafely<T>(response);
@@ -286,7 +298,11 @@ export const apiDelete = async <T>(endpoint: string, data?: unknown, token?: str
       const responseText = await response.text().catch(() => "Unable to read response");
       logger.log(`[API] Error response body:`, responseText);
 
-      throw new ApiError(`HTTP error! status: ${response.status}`, response.status, endpoint);
+      let errorMessage = `HTTP error! status: ${response.status}`;
+      if (responseText) {
+        errorMessage += ` - ${responseText}`;
+      }
+      throw new ApiError(errorMessage, response.status, endpoint);
     }
 
     const result = await parseJsonSafely<T>(response);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
[GLB-63](https://globber-app.atlassian.net/browse/GLB-63?atlOrigin=eyJpIjoiNWNhZDdmZWY0MzA3NDczMjlmMjA4ZWMxM2Q2N2VmOWUiLCJwIjoiaiJ9)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
: **이미지 메타데이터 뷰 내 사진 드래그 앤 드롭 이동 기능 추가 및 정렬 로직 대응**

- `@dnd-kit`을 활용하여 수평 드래그 앤 드롭(Drag & Drop) 위치 변경 기능 구현
- UI/UX 인터랙션 스펙 적용
  - 활성화(Pressed, Active) 상태별 스케일(Scale) 조절 및 배경 Dim 처리
  - 이동 시 1.08배 확대 + 테두리(Outline) 및 좌측 회전(-2deg) 애니메이션 적용
- 데스크탑 / 모바일 UX 환경 분리
  - 터치(모바일): 기존 명세대로 1초 지연(Delay=1000) 롱프레스 시 드래그 활성화
  - 마우스(PC): 즉시 10px 이동 시(Distance=10) 바로 드래그가 활성화되도록 분기하여 답답함 개선

## 🐛 버그 수정 및 리팩토링
- **PC 브라우저 드래그 이벤트 충돌 해결**:
  - Image 기본 동작인 고스트 이미지 드래그 방지 (`draggable={false}`)
  - 원래 존재하던 이미지 자체의 `onClick` 트리거(crop 모달) 영역 제거
- **저장 시 순서 누락 오류 해결 (`useDiaryAction.ts`)**:
  - 기존엔 수정(isEditMode) 시에만 사진 배열 상태를 Local Cache(SessionStorage)에 매핑했으나, 신규 생성(Create) 요청 직후에도 반환된 `diaryId`와 함께 저장되도록 수정.
- **`/record` 페이지 렌더링 방식(SSR) 충돌 임시 대응 (`RecordDetailClient.tsx`)**:
  - Record 뷰가 SSR로 개편되면서, 브라우저 스토리지인 SessionStorage의 순서 매핑을 누락한 채 데이터베이스가 반환한 업로드 순서(`photoId` 기준)만 100% 렌더링 하던 현상을 해결.
  - SSR에서 내려준 원래 데이터를 `useEffect` (클라이언트 마운팅 시점)를 통해 SessionStorage 기준으로 다시 재배치하도록 클라이언트 하이드레이션 로직 추가.

## 📸 스크린샷 (선택)
<!-- 구현된 드래그 앤 드롭 화면이나 인터랙션 모습을 GIF 또는 사진으로 첨부해주세요 -->


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[GLB-63]: https://globber-app.atlassian.net/browse/GLB-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 갤러리에서 이미지를 드래그하여 순서를 변경할 수 있는 기능 추가
  * 이미지 순서 변경 시 설정 저장 및 복원 기능 구현

* **Chores**
  * 드래그 앤 드롭 기능 지원을 위한 라이브러리 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->