### PR TITLE
[GLB-63] PointerSensor 전환으로 모바일 드래그 정렬 부드러움 개선

### DIFF
--- a/src/components/imageMetadata/ImageUploadSection.tsx
+++ b/src/components/imageMetadata/ImageUploadSection.tsx
@@ -9,8 +9,7 @@ import {
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
-  MouseSensor,
-  TouchSensor,
+  PointerSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -51,6 +50,7 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
     transition,
     opacity: isDragging ? 0 : 1, // Hide original item completely so DragOverlay is the only one visible
     zIndex: isDragging ? 0 : 1,
+    touchAction: "none" as const,
   };
 
   return (
@@ -70,6 +70,18 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
       onPointerCancel={e => {
         onPressEnd();
         listeners?.onPointerCancel?.(e);
+      }}
+      onTouchStart={e => {
+        onPressStart();
+        listeners?.onTouchStart?.(e);
+      }}
+      onTouchEnd={e => {
+        onPressEnd();
+        listeners?.onTouchEnd?.(e);
+      }}
+      onTouchCancel={e => {
+        onPressEnd();
+        listeners?.onTouchCancel?.(e);
       }}
       className="shrink-0 outline-none select-none relative"
     >
@@ -109,15 +121,9 @@ export const ImageUploadSection = ({
   const [pressingId, setPressingId] = useState<string | null>(null);
 
   const sensors = useSensors(
-    useSensor(MouseSensor, {
+    useSensor(PointerSensor, {
       activationConstraint: {
-        distance: 10,
-      },
-    }),
-    useSensor(TouchSensor, {
-      activationConstraint: {
-        delay: 1000,
-        tolerance: 15,
+        distance: 6,
       },
     })
   );
@@ -156,7 +162,7 @@ export const ImageUploadSection = ({
   const renderContent = () => (
     <div
       className="flex gap-4 overflow-x-auto px-4 pb-6 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
-      style={{ touchAction: "pan-x", minHeight: hasImages ? undefined : "460px" }}
+      style={{ touchAction: isDndEnabled ? "pan-y" : "pan-x", minHeight: hasImages ? undefined : "460px" }}
     >
       {!hasImages && (
         <div className="shrink-0">


### PR DESCRIPTION
## #️⃣연관된 이슈

> GLB-63

## 📝작업 내용
[GLB-63](https://github.com/depromeet/17th-team1-client/pull/195) > 모바일 드래그앤드롭 안되는 이슈 개선&테스트

**모바일에서 이미지 순서 변경(DnD)이 끊기거나 시작이 늦는 이슈를 개선했습니다.**
- 입력 센서를 MouseSensor + TouchSensor에서 PointerSensor 단일 경로로 통합해, 디바이스별 제스처 판정 불일치를 줄였습니다.
- 드래그 시작 임계값을 distance: 6으로 조정해 모바일에서 반응성을 높였습니다.
- Sortable 카드에 touchAction: "none"을 적용해 브라우저 기본 터치 제스처와 드래그 충돌을 줄였습니다.
- 카드 터치 이벤트(onTouchStart/End/Cancel)에서 press 상태를 명시적으로 제어해 모바일 피드백(눌림 상태) 안정성을 보강했습니다.
- 컨테이너의 touchAction을 DnD 활성 시 pan-y로 분기해, 가로 드래그 중 스크롤 간섭을 완화했습니다.

**확인한 기대 효과**
- 모바일에서 순서 변경 시작 지연이 줄어듦
- 드래그 중 끊김/미인식 빈도 감소
- PC 동작은 기존과 동일하게 유지

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

@yuminnnnni 
확인해보고 이상없으면 GLB-63에 머지하면 될 것 같습니다!