### PR TITLE
[GLB-71] 모바일에서 이미지 캐러셀 드래그앤드롭 시 가로 스크롤이 되지 않는 문제 해결

### DIFF
--- a/src/components/imageMetadata/ImageUploadSection.tsx
+++ b/src/components/imageMetadata/ImageUploadSection.tsx
@@ -10,6 +10,7 @@ import {
   DragOverlay,
   DragStartEvent,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -48,9 +49,9 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0 : 1, // Hide original item completely so DragOverlay is the only one visible
+    opacity: isDragging ? 0 : 1,
     zIndex: isDragging ? 0 : 1,
-    touchAction: "none" as const,
+    touchAction: "pan-x" as const,
   };
 
   return (
@@ -89,7 +90,7 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
         style={{
           transform: isPressing && !isDragging ? "scale(0.96)" : "scale(1)",
           transition: "transform 0.2s ease, filter 0.2s ease",
-          borderRadius: "0.75rem", // match xl
+          borderRadius: "0.75rem",
         }}
         className="relative origin-center"
       >
@@ -124,6 +125,12 @@ export const ImageUploadSection = ({
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 6,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 1000,
+        tolerance: 8,
       },
     })
   );
@@ -270,14 +277,13 @@ export const ImageUploadSection = ({
                 style={{
                   transform: "scale(1.08) rotate(-2deg)",
                   transformOrigin: "center center",
-                  transition: "none", // dnd-kit will handle overlay transition if needed, but we keep it static while moving
+                  transition: "none",
                 }}
                 className="shrink-0 relative outline-none select-none"
               >
                 <div className="absolute inset-0 border-2 border-[#0097C1] rounded-xl z-20 pointer-events-none" />
                 <ImageCarousel
                   image={activeMetadata}
-                  // pass empty handlers or actual handlers for overlay visual completeness
                   onRemove={() => {}}
                   onImageUpdate={handleImageUpdate}
                   onTagChange={() => {}}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
[GLB-71](https://globber-app.atlassian.net/browse/GLB-71?atlOrigin=eyJpIjoiZWM5NzJhYjIxMmEzNGZiMmE4YWI1ZDNjZWQ1ODExZWEiLCJwIjoiaiJ9)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이미지가 2장 이상일 때 PC 트랙패드에서는 가로 스크롤이 정상 동작하지만, 모바일에서는 가로 스크롤이 불가능하고 드래그앤드롭만 동작하는 버그가 있었습니다.

**[원인]**
- SortableImageCard에 touchAction: "none" 적용 → 터치로 시작된 모든 제스처를 JS가 독점, 브라우저의 네이티브 스크롤이 완전히 차단됨
- PointerSensor의 activationConstraint.distance: 6 → 손가락을 6px만 움직여도 즉시 드래그로 인식됨

PC 트랙패드는 wheel 이벤트를 사용하기 때문에 touchAction의 영향을 받지 않아 정상 동작했습니다.

**[변경 내용]**
- touchAction: "none" → touchAction: "pan-x" 변경
- 빠른 가로 스와이프는 브라우저가 네이티브 스크롤로 처리
- TouchSensor 추가 (delay: 1000, tolerance: 8)
- 모바일에서 1초 길게 누른 경우에만 드래그앤드롭 활성화

**[체크 필요]**
- [ ] 모바일 환경에서 이미지 2장 이상일 때 가로 스크롤 정상 동작 확인
- [ ] 모바일 환경에서 1초 길게 누른 후 드래그앤드롭으로 순서 변경 가능 확인
- [ ] PC에서 기존과 동일하게 트랙패드 가로 스크롤 및 마우스 드래그 정상 동작 확인

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 터치 기기에서 이미지 드래그 앤 드롭 지원 추가

* **스타일**
  * 드래그 중 이미지 카드의 시각적 피드백 개선
  * 드래그 오버레이 시각 효과 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->