### PR TITLE
fix: DnD로 인한 가로 스크롤 불가 문제 수정

### DIFF
--- a/src/components/imageMetadata/ImageUploadSection.tsx
+++ b/src/components/imageMetadata/ImageUploadSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   closestCenter,
@@ -9,7 +9,7 @@ import {
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
-  PointerSensor,
+  MouseSensor,
   TouchSensor,
   useSensor,
   useSensors,
@@ -51,6 +51,7 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
     transition,
     opacity: isDragging ? 0 : 1,
     zIndex: isDragging ? 0 : 1,
+    // pan-x: 터치 가로 스크롤 허용 (DnD 라이브러리가 delay 이후 override함)
     touchAction: "pan-x" as const,
   };
 
@@ -60,18 +61,6 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
       style={style}
       {...attributes}
       {...listeners}
-      onPointerDown={e => {
-        onPressStart();
-        listeners?.onPointerDown?.(e);
-      }}
-      onPointerUp={e => {
-        onPressEnd();
-        listeners?.onPointerUp?.(e);
-      }}
-      onPointerCancel={e => {
-        onPressEnd();
-        listeners?.onPointerCancel?.(e);
-      }}
       onTouchStart={e => {
         onPressStart();
         listeners?.onTouchStart?.(e);
@@ -83,6 +72,22 @@ const SortableImageCard = ({ id, isPressing, onPressStart, onPressEnd, children 
       onTouchCancel={e => {
         onPressEnd();
         listeners?.onTouchCancel?.(e);
+      }}
+      onPointerDown={e => {
+        // 터치 이벤트는 onTouchStart에서 처리하므로 마우스만
+        if (e.pointerType === "mouse") onPressStart();
+        listeners?.onPointerDown?.(e);
+      }}
+      onPointerUp={e => {
+        if (e.pointerType === "mouse") onPressEnd();
+        listeners?.onPointerUp?.(e);
+      }}
+      onPointerCancel={e => {
+        onPressEnd();
+        listeners?.onPointerCancel?.(e);
+      }}
+      onContextMenu={e => {
+        e.preventDefault();
       }}
       className="shrink-0 outline-none select-none relative"
     >
@@ -120,20 +125,30 @@ export const ImageUploadSection = ({
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const [pressingId, setPressingId] = useState<string | null>(null);
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 6,
-      },
-    }),
+  useEffect(() => {
+    setIsTouchDevice(window.matchMedia("(pointer: coarse)").matches);
+  }, []);
+
+  const touchSensors = useSensors(
     useSensor(TouchSensor, {
       activationConstraint: {
         delay: 1000,
-        tolerance: 8,
+        tolerance: 10,
       },
     })
   );
+
+  const mouseSensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 6,
+      },
+    })
+  );
+
+  const sensors = isTouchDevice ? touchSensors : mouseSensors;
 
   const triggerFileInput = () => {
     document.getElementById(fileUploadId)?.click();
@@ -169,7 +184,7 @@ export const ImageUploadSection = ({
   const renderContent = () => (
     <div
       className="flex gap-4 overflow-x-auto px-4 pb-6 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
-      style={{ touchAction: isDndEnabled ? "pan-y" : "pan-x", minHeight: hasImages ? undefined : "460px" }}
+      style={{ touchAction: "pan-x", minHeight: hasImages ? undefined : "460px" }}
     >
       {!hasImages && (
         <div className="shrink-0">


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
[GLB-71](https://globber-app.atlassian.net/browse/GLB-71?atlOrigin=eyJpIjoiZWM5NzJhYjIxMmEzNGZiMmE4YWI1ZDNjZWQ1ODExZWEiLCJwIjoiaiJ9)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**문제**
사진이 2장 이상일 때 이미지 캐러셀에서 가로 스크롤이 되지 않는 문제가 있었습니다. 또한 사진을 1초 이상 길게 누르면 DnD 대신 브라우저 기본 이미지 저장 팝업이 노출되었습니다.

**원인**
- PointerSensor(distance: 6)가 TouchSensor(delay: 1000)보다 우선 발동되어, 손가락을 6px만 움직여도 DnD가 시작됨
- 컨테이너 touchAction이 DnD 활성 시 pan-y로 설정되어 있어 브라우저 수준에서 가로 터치 이동이 차단됨
- onContextMenu 이벤트가 막혀있지 않아 long-press 시 이미지 저장 팝업이 표시됨

**해결**
- 터치 기기(pointer: coarse)에서는 TouchSensor만 사용, 데스크톱에서는 MouseSensor만 사용하도록 분리
- 모바일: 1초 이상 누른 후에만 DnD 활성화 → 그 전까지 가로 스크롤 정상 동작
- 컨테이너 touchAction을 항상 pan-x로 고정하여 가로 스크롤 보장
- onContextMenu에 e.preventDefault() 추가하여 브라우저 이미지 저장 팝업 차단

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* 터치 기기와 마우스 환경에 최적화된 드래그 앤 드롭 기능 동작 개선
* 이미지 카드에서 우클릭 시 컨텍스트 메뉴 처리 강화
* 모바일 기기에서 터치 스크롤 시 수평 스크롤 경험 최적화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/17th-team1-client/pull/204)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->