### PR TITLE
fix: HEIC 이미지를 S3 업로드 전 JPEG으로 변환

### DIFF
--- a/src/components/imageMetadata/hooks/useImageMetadata.ts
+++ b/src/components/imageMetadata/hooks/useImageMetadata.ts
@@ -186,16 +186,16 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
         const remainingSlots = MAX_IMAGES - metadataCount;
         if (remainingSlots <= 0) return;
 
-        const tasks: Promise<{ metadata: ImageMetadata; file: File }>[] = [];
+        const tasks: Promise<{ metadata: ImageMetadata; uploadFile: File }>[] = [];
         const filesToProcess = Math.min(files.length, remainingSlots);
 
         for (let i = 0; i < filesToProcess; i++) {
           const f = files[i];
           if (f.type.startsWith("image/")) {
             tasks.push(
-              processSingleFile(f).then(metadata => ({
+              processSingleFile(f).then(({ metadata, uploadFile }) => ({
                 metadata,
-                file: f,
+                uploadFile,
               }))
             );
           }
@@ -203,13 +203,15 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
 
         const settled = await Promise.allSettled(tasks);
         const results = settled
-          .filter((r): r is PromiseFulfilledResult<{ metadata: ImageMetadata; file: File }> => r.status === "fulfilled")
+          .filter(
+            (r): r is PromiseFulfilledResult<{ metadata: ImageMetadata; uploadFile: File }> => r.status === "fulfilled"
+          )
           .map(r => r.value);
 
         if (results.length === 0) return;
 
-        const uploadPromises = results.map(({ metadata, file }) =>
-          uploadTravelPhoto({ file }).then(photoCode => ({
+        const uploadPromises = results.map(({ metadata, uploadFile }) =>
+          uploadTravelPhoto({ file: uploadFile }).then(photoCode => ({
             photoCode,
             metadata,
           }))

--- a/src/lib/processFile.ts
+++ b/src/lib/processFile.ts
@@ -37,7 +37,7 @@ async function getImageDimensions(file: File): Promise<{ width: number; height: 
   });
 }
 
-export async function processSingleFile(file: File): Promise<ImageMetadata> {
+export async function processSingleFile(file: File): Promise<{ metadata: ImageMetadata; uploadFile: File }> {
   const id = Math.random().toString(36).substr(2, 9);
   const extracted: ImageMetadata = {
     id,
@@ -48,7 +48,11 @@ export async function processSingleFile(file: File): Promise<ImageMetadata> {
     status: "processing",
   };
 
+  // HEIC 파일 여부 판별 (MIME 타입 또는 확장자 기준)
   const isHeic = file.type.toLowerCase().includes("heic") || /\.heic$/i.test(file.name);
+  // S3에 실제로 올릴 파일 (HEIC → JPEG 변환 성공 시 교체, 아니면 원본 유지)
+  let uploadFile: File = file;
+
   if (isHeic) {
     try {
       const { default: heic2any } = await import("heic2any");
@@ -59,10 +63,14 @@ export async function processSingleFile(file: File): Promise<ImageMetadata> {
       });
       const jpegBlob = Array.isArray(converted) ? converted[0] : converted;
       if (jpegBlob instanceof Blob) {
-        // 메모리 누수 방지: 기존 Object URL 해제
+        // 미리보기 URL 교체 (메모리 누수 방지: 기존 Object URL 해제)
         const newUrl = URL.createObjectURL(jpegBlob);
         URL.revokeObjectURL(extracted.imagePreview);
         extracted.imagePreview = newUrl;
+
+        // S3 업로드용 JPEG File 객체 생성 (.heic → .jpg, MIME 타입 image/jpeg)
+        const jpegFileName = file.name.replace(/\.(heic|heif)$/i, ".jpg");
+        uploadFile = new File([jpegBlob], jpegFileName, { type: "image/jpeg" });
       }
     } catch {
       try {
@@ -130,11 +138,11 @@ export async function processSingleFile(file: File): Promise<ImageMetadata> {
     if (exifData.DateTimeOriginal) extracted.timestamp = new Date(exifData.DateTimeOriginal as string).toISOString();
     if (exifData.Orientation) extracted.orientation = exifData.Orientation as number;
     extracted.status = "completed";
-    return extracted;
+    return { metadata: extracted, uploadFile };
   } catch (e: unknown) {
     const error = e as Error;
     extracted.status = "error";
     extracted.error = error?.message || "알 수 없는 오류";
-    return extracted;
+    return { metadata: extracted, uploadFile };
   }
 }

--- a/src/lib/processFile.ts
+++ b/src/lib/processFile.ts
@@ -48,8 +48,12 @@ export async function processSingleFile(file: File): Promise<{ metadata: ImageMe
     status: "processing",
   };
 
-  // HEIC 파일 여부 판별 (MIME 타입 또는 확장자 기준)
-  const isHeic = file.type.toLowerCase().includes("heic") || /\.heic$/i.test(file.name);
+  // HEIC/HEIF 파일 여부 판별 (MIME 타입 또는 확장자 기준)
+  const isHeic =
+    file.type.toLowerCase().includes("heic") ||
+    file.type.toLowerCase().includes("heif") ||
+    /\.heic$/i.test(file.name) ||
+    /\.heif$/i.test(file.name);
   // S3에 실제로 올릴 파일 (HEIC → JPEG 변환 성공 시 교체, 아니면 원본 유지)
   let uploadFile: File = file;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

[GLB-81](https://globber-app.atlassian.net/browse/GLB-81?atlOrigin=eyJpIjoiMDgxNDg2NDdhODk0NDk3YzllNjQxYTk5NDM1MWNhN2UiLCJwIjoiaiJ9)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 문제

HEIC 확장자 이미지를 업로드할 때 미리보기는 정상적으로 표시됐지만,
실제 S3에는 원본 HEIC 파일이 그대로 업로드되고 있었습니다.

이로 인해 record 페이지 등 S3 URL로 이미지를 조회하는 화면에서
Android / Windows Chrome 환경의 사용자에게 이미지가 표시되지 않는 문제가 발생했습니다.

## 원인

`processSingleFile`이 HEIC → JPEG 변환을 **미리보기(`imagePreview`) 목적으로만** 수행했고,
`uploadTravelPhoto`에는 변환 전 원본 `file` 객체가 그대로 전달되고 있었습니다.

## 해결

`processSingleFile`이 HEIC 변환에 성공할 경우,
미리보기용 URL과 함께 S3 업로드용 JPEG `File` 객체(`uploadFile`)도 함께 반환하도록 변경했습니다.
`useImageMetadata`의 `handleFileUpload`에서 이 `uploadFile`을 `uploadTravelPhoto`에 전달합니다.

- HEIC → `uploadFile` = 변환된 JPEG File (파일명 `.jpg`, Content-Type `image/jpeg`)
- 일반 이미지 → `uploadFile` = 원본 파일 그대로

## 변경 파일

- `src/lib/processFile.ts`
  - 반환 타입 `ImageMetadata` → `{ metadata: ImageMetadata; uploadFile: File }`
  - HEIC 변환 성공 시 `uploadFile`에 JPEG `File` 객체 할당

- `src/components/imageMetadata/hooks/useImageMetadata.ts`
  - `processSingleFile` 결과에서 `uploadFile`을 구조분해해 `uploadTravelPhoto`에 전달


### 스크린샷 (선택)
<img width="720" height="117" alt="스크린샷 2026-05-26 오후 8 32 23" src="https://github.com/user-attachments/assets/960a178d-9066-4468-906a-2b5a7e9b0ad2" />
- heic -> jpeg로 변환 & 업로드 완료


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * HEIC/HEIF 형식 이미지 업로드 처리 개선으로 변환 및 업로드 안정성 강화
  * 이미지 메타데이터 추출 및 업로드 프로세스 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/17th-team1-client/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->