### PR TITLE
fix: Android 드래그앤드롭 미동작 문제 수정 (PointerSensor 적용)

### DIFF
--- a/src/components/imageMetadata/ImageUploadSection.tsx
+++ b/src/components/imageMetadata/ImageUploadSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   closestCenter,
@@ -9,8 +9,7 @@ import {
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
-  MouseSensor,
-  TouchSensor,
+  PointerSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -127,31 +126,16 @@ export const ImageUploadSection = ({
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const [pressingId, setPressingId] = useState<string | null>(null);
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    setIsTouchDevice(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
-
-  const touchSensors = useSensors(
-    useSensor(TouchSensor, {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
       activationConstraint: {
-        delay: 1000,
-        tolerance: 10,
+        delay: 500,
+        tolerance: 15,
       },
     })
   );
-
-  const mouseSensors = useSensors(
-    useSensor(MouseSensor, {
-      activationConstraint: {
-        distance: 6,
-      },
-    })
-  );
-
-  const sensors = isTouchDevice ? touchSensors : mouseSensors;
 
   const triggerFileInput = () => {
     document.getElementById(fileUploadId)?.click();


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
[GLB-83](https://globber-app.atlassian.net/browse/GLB-83?atlOrigin=eyJpIjoiYjMyMDI1YWUyMzk1NDFhMGI3NzM3NmE2MmFhMmI2ZGIiLCJwIjoiaiJ9)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 개요
image-metadata 페이지에서 안드로이드 기기로 사진 드래그앤드롭이 동작하지 않는 버그를 수정합니다.

## 원인
기존 구현에서 `TouchSensor`(delay: 1000ms)와 `MouseSensor`를 기기 타입에 따라 분기하는 방식을 사용했는데,
Android Chrome / WebView 환경에서 아래 이유로 정상 동작하지 않았습니다.

- `delay: 1000ms` 롱프레스 대기 중 Android 브라우저가 스크롤 제스처를 선점
- `tolerance: 10px`으로 인해 손 떨림 수준의 움직임에도 활성화 취소
- `window.matchMedia("(pointer: coarse)")` 감지가 일부 Android 브라우저에서 불안정하게 반환되어 `MouseSensor`가 대신 적용되는 경우 발생

## 변경 사항
- `TouchSensor` / `MouseSensor` 분기 제거
- `PointerSensor` 단일 센서로 통일 (Pointer Events API 기반으로 마우스·터치 통합 처리)
- activation delay 1000ms → 500ms 단축
- tolerance 10px → 15px으로 확대
- `isTouchDevice` 상태 및 `useEffect` 제거

## 영향 범위
- `src/components/imageMetadata/ImageUploadSection.tsx`

## 테스트
- [ ] Android Chrome에서 사진 2~3장 업로드 후 드래그앤드롭 순서 변경 확인
- [ ] iOS Safari에서 정상 동작 확인
- [ ] PC(Chrome, Safari)에서 마우스 드래그 정상 동작 확인

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 파일 업로드 시 드래그 앤 드롭 감지 방식이 개선되었습니다. 이제 모든 입력 장치(터치, 마우스 등)에서 더욱 일관되게 작동합니다. 드래그 감지 지연 시간이 500ms로 설정되어 실수로 인한 동작을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->