### PR TITLE
[GLB-90] 메타데이터 날짜 칩 삭제 처리 수정

### DIFF
--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -52,13 +52,14 @@ export const ImageCarousel = ({
   const [isCropModalOpen, setIsCropModalOpen] = useState(false);
   const [isCropUploading, setIsCropUploading] = useState(false);
   const [currentImage, setCurrentImage] = useState(image.imagePreview);
-  const [customDate, setCustomDate] = useState<string | null>(image.customDate ?? toYearMonth(image.timestamp));
+  const [customDate, setCustomDate] = useState<string | null>(
+    image.customDate === undefined ? toYearMonth(image.timestamp) : image.customDate
+  );
   const [customLocation, setCustomLocation] = useState<string | null>(
     image.location?.nearbyPlaces?.[1] || image.location?.address || null
   );
 
-  const baseDate = toYearMonth(image.timestamp);
-  const displayedYearMonth = customDate ?? baseDate;
+  const displayedYearMonth = customDate;
   const displayDate = formatYearMonth(displayedYearMonth);
   const hasDate = !!displayedYearMonth;
 
@@ -67,7 +68,7 @@ export const ImageCarousel = ({
   }, [image.selectedTag, image.tag]);
 
   useEffect(() => {
-    setCustomDate(image.customDate ?? toYearMonth(image.timestamp));
+    setCustomDate(image.customDate === undefined ? toYearMonth(image.timestamp) : image.customDate);
   }, [image.customDate, image.timestamp]);
 
   useEffect(() => {
@@ -101,12 +102,12 @@ export const ImageCarousel = ({
 
   const handleConfirmDate = (date: string) => {
     const normalized = date.replace(".", "");
-    const changeType = !customDate ? "add" : "update";
+    const changeType = !displayedYearMonth ? "add" : "update";
     sendGAEvent("event", "record_meta_date_change", {
       flow: "editor",
       screen: "record_edit",
       click_code: "editor.record.edit.meta.date.edit",
-      date_before: formatDateForGA(customDate),
+      date_before: formatDateForGA(displayedYearMonth),
       date_after: formatDateForGA(normalized),
       change_type: changeType,
     });
@@ -119,12 +120,21 @@ export const ImageCarousel = ({
       flow: "editor",
       screen: "record_edit",
       click_code: "editor.record.edit.meta.date.remove",
-      date_before: formatDateForGA(customDate),
+      date_before: formatDateForGA(displayedYearMonth),
       date_after: null,
       change_type: "remove",
     });
     setCustomDate(null);
     onDateChange?.(null);
+  };
+
+  const handleDateChipClick = () => {
+    if (hasDate) {
+      handleDateClear();
+      return;
+    }
+
+    setIsDateSelectModalOpen(true);
   };
 
   const handleSaveCroppedImage = async (croppedImage: string) => {
@@ -256,7 +266,7 @@ export const ImageCarousel = ({
         <MetadataChip
           iconType="calendar"
           text={hasDate && displayDate ? displayDate : "날짜 추가"}
-          onClick={() => setIsDateSelectModalOpen(true)}
+          onClick={handleDateChipClick}
           onRemove={hasDate ? handleDateClear : undefined}
           isPlaceholder={!hasDate || !displayDate}
         />

--- a/src/components/imageMetadata/MetadataChip.tsx
+++ b/src/components/imageMetadata/MetadataChip.tsx
@@ -46,12 +46,16 @@ export const MetadataChip = ({
   if (onClick && onRemove) {
     return (
       <div className={`${baseClasses} relative`}>
-        <button onClick={onClick} className="flex items-center gap-2" type="button">
+        <button
+          onClick={onClick}
+          className="flex items-center gap-2 -m-1.5 pl-1.5 pr-7 py-1.5 cursor-pointer"
+          type="button"
+        >
           {/* Left Icon */}
           <div className="flex-shrink-0">{renderIcon()}</div>
 
           {/* Center Text */}
-          <span className={`text-sm font-medium truncate max-w-[170px] ${textClasses} pr-[18px]`}>{text}</span>
+          <span className={`text-sm font-medium truncate max-w-[170px] ${textClasses}`}>{text}</span>
         </button>
 
         {/* Right X Icon */}
@@ -69,7 +73,7 @@ export const MetadataChip = ({
 
   if (onClick) {
     return (
-      <button onClick={onClick} className={baseClasses} type="button">
+      <button onClick={onClick} className={`${baseClasses} cursor-pointer`} type="button">
         {/* Left Icon */}
         <div className="flex-shrink-0">{renderIcon()}</div>
 


### PR DESCRIPTION
## 관련 이슈
[GLB-90](https://globber-app.atlassian.net/browse/GLB-90?atlOrigin=eyJpIjoiZjBiNjUxZjcyZTBlNGE4YmI4YjJhMmQxOTE5YzJmYmEiLCJwIjoiaiJ9)

## 작업 내용
- 날짜를 삭제한 뒤에도 원본 촬영 날짜가 다시 노출되지 않도록 수정
- 날짜 칩 클릭 시 현재 날짜가 있으면 삭제, 없으면 날짜 선택을 열도록 처리
- 날짜/위치 메타데이터 칩에 pointer 커서 적용

## 확인
- pnpm exec prettier --check src/components/imageMetadata/ImageCarousel.tsx src/components/imageMetadata/MetadataChip.tsx
- pnpm exec eslint src/components/imageMetadata/ImageCarousel.tsx src/components/imageMetadata/MetadataChip.tsx
- 커밋 훅 lint-staged 통과
- push 훅 타입 검사 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 이미지 날짜 표시 방식이 더 정확해졌습니다. 기본 날짜, 직접 지정한 날짜, 날짜 없음 상태가 더 명확히 구분됩니다.
  * 날짜 칩을 누르면 현재 상태에 따라 날짜를 바로 삭제하거나, 날짜 선택 창이 열리도록 동작이 개선되었습니다.
* **버그 수정**
  * 날짜 정보가 바뀔 때 화면에 표시되는 연/월이 실제 상태와 더 잘 맞도록 수정되었습니다.
  * 날짜 관련 버튼과 칩의 레이아웃 및 클릭 가능 표시가 개선되어 사용성이 좋아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->