### PR TITLE
[GLB-59] 리스트/지구본 뷰 썸네일 > 기록 여러개일때 겹침 대신 딤드+잔여 개수 뱃지로 표시

### DIFF
--- a/src/app/globe/[id]/page.tsx
+++ b/src/app/globe/[id]/page.tsx
@@ -90,13 +90,19 @@ const GlobePage = () => {
           cityThumbnails,
           countryThumbnails: countryThumbMap,
           cityThumbnailsArray,
+          cityDiaryCount,
         } = getDiaryThumbnails(diaryData);
 
         // 국가 썸네일 state 설정
         setCountryThumbnails(countryThumbMap);
 
         if (globeResponse?.data) {
-          const mappedPatterns = mapGlobeDataToTravelPatterns(globeResponse.data, cityThumbnails, cityThumbnailsArray);
+          const mappedPatterns = mapGlobeDataToTravelPatterns(
+            globeResponse.data,
+            cityThumbnails,
+            cityThumbnailsArray,
+            cityDiaryCount
+          );
           setTravelPatterns(mappedPatterns);
 
           // 도시와 국가 개수 설정

--- a/src/components/globe/Globe.tsx
+++ b/src/components/globe/Globe.tsx
@@ -178,6 +178,7 @@ const Globe = forwardRef<GlobeRef, GlobeProps>(
           const cityHasRecords = clusterData.hasRecords ?? false;
           const thumbnailUrl = clusterData.thumbnailUrl;
           const cityId = clusterData.items?.[0]?.cityId;
+          const recordCount = clusterData.recordCount;
 
           el.innerHTML = createCityHTML(
             styles as CityStyles,
@@ -186,7 +187,8 @@ const Globe = forwardRef<GlobeRef, GlobeProps>(
             cityHasRecords,
             thumbnailUrl,
             isMyGlobe,
-            isFirstGlobe
+            isFirstGlobe,
+            recordCount
           );
 
           // 타인의 지구본에서 기록이 없는 경우 클릭 비활성화

--- a/src/components/listview/ListView.tsx
+++ b/src/components/listview/ListView.tsx
@@ -36,6 +36,7 @@ type GroupedByCountry = {
     lng: number;
     thumbnailUrl?: string;
     thumbnails?: string[]; // 여행기록 썸네일 배열 (최대 2개, 최신순)
+    recordCount?: number; // 해당 도시의 총 여행 기록 개수
     hasRecords: boolean;
     cityId?: number;
   }>;
@@ -68,6 +69,7 @@ const ListView = ({ travelPatterns, isMyGlobe = true }: ListViewProps) => {
             lng: country.lng,
             thumbnailUrl: country.thumbnailUrl,
             thumbnails: country.thumbnails,
+            recordCount: country.recordCount,
             hasRecords: country.hasRecords ?? false,
             cityId: country.cityId,
           });
@@ -216,9 +218,11 @@ const ListView = ({ travelPatterns, isMyGlobe = true }: ListViewProps) => {
 
                 {/* 도시 칩 목록 */}
                 <div className="flex flex-wrap gap-2">
-                  {group.cities.map(({ name, hasRecords, thumbnails }) => {
+                  {group.cities.map(({ name, hasRecords, thumbnails, recordCount }) => {
                     // "도시명, 국가명" 형식에서 도시명만 추출
                     const cityName = name.split(",")[0].trim();
+                    const totalRecords = recordCount ?? thumbnails?.length ?? 0;
+                    const extraCount = totalRecords - 1;
 
                     return (
                       <button
@@ -253,64 +257,36 @@ const ListView = ({ travelPatterns, isMyGlobe = true }: ListViewProps) => {
                           >
                             {cityName}
                           </p>
-                          {/* 여행기록이 있는 경우 썸네일 표시 */}
+                          {/* 여행기록이 있는 경우 가장 최근 썸네일만 표시 */}
                           {hasRecords && thumbnails && thumbnails.length > 0 && (
-                            <div className="flex items-center" style={{ position: "relative" }}>
-                              {thumbnails.length === 1 ? (
-                                // 썸네일이 1개인 경우
+                            <div
+                              className="border rounded-sm shrink-0 overflow-hidden relative"
+                              style={{
+                                width: "24px",
+                                height: "24px",
+                                borderColor: "rgba(255, 255, 255, 0.16)",
+                              }}
+                            >
+                              <Image
+                                src={thumbnails[0]}
+                                alt={cityName}
+                                width={24}
+                                height={24}
+                                className="w-full h-full object-cover rounded-sm"
+                              />
+                              {/* 기록이 2개 이상인 경우 딤드 + 잔여 개수 뱃지 표시 */}
+                              {extraCount > 0 && (
                                 <div
-                                  className="border border-white rounded-sm shrink-0 overflow-hidden"
-                                  style={{ width: "24px", height: "24px" }}
+                                  className="absolute inset-0 flex items-center justify-center"
+                                  style={{ backgroundColor: "rgba(0, 0, 0, 0.2)" }}
                                 >
-                                  <Image
-                                    src={thumbnails[0]}
-                                    alt={cityName}
-                                    width={24}
-                                    height={24}
-                                    className="w-full h-full object-cover rounded-sm"
-                                  />
+                                  <p
+                                    className="font-bold text-white"
+                                    style={{ fontSize: "12px", letterSpacing: "-0.24px" }}
+                                  >
+                                    +{extraCount}
+                                  </p>
                                 </div>
-                              ) : (
-                                // 썸네일이 2개 이상인 경우 겹침 표시 (최대 2개)
-                                <>
-                                  {/* 이전 썸네일 (왼쪽, z-index 낮음) */}
-                                  <div
-                                    className="border border-white rounded-sm shrink-0 overflow-hidden"
-                                    style={{
-                                      width: "24px",
-                                      height: "24px",
-                                      position: "relative",
-                                      zIndex: 1,
-                                      marginRight: "-8px",
-                                    }}
-                                  >
-                                    <Image
-                                      src={thumbnails[1]}
-                                      alt={`${cityName} 이전`}
-                                      width={24}
-                                      height={24}
-                                      className="w-full h-full object-cover rounded-sm"
-                                    />
-                                  </div>
-                                  {/* 최신 썸네일 (우측, z-index 높음) */}
-                                  <div
-                                    className="border border-white rounded-sm shrink-0 overflow-hidden"
-                                    style={{
-                                      width: "24px",
-                                      height: "24px",
-                                      position: "relative",
-                                      zIndex: 2,
-                                    }}
-                                  >
-                                    <Image
-                                      src={thumbnails[0]}
-                                      alt={`${cityName} 최신`}
-                                      width={24}
-                                      height={24}
-                                      className="w-full h-full object-cover rounded-sm"
-                                    />
-                                  </div>
-                                </>
                               )}
                             </div>
                           )}

--- a/src/lib/globe/clustering/clusterCreators.ts
+++ b/src/lib/globe/clustering/clusterCreators.ts
@@ -87,7 +87,7 @@ export const createCountryClusters = (
  */
 export const createIndividualCityClusters = (locations: CountryData[]): ClusterData[] => {
   return locations.map(location => {
-    const { id, lat, lng, name, flag, color, hasRecords, thumbnailUrl } = location;
+    const { id, lat, lng, name, flag, color, hasRecords, thumbnailUrl, recordCount } = location;
 
     return {
       id: `${id}_${lat}_${lng}`,
@@ -101,6 +101,7 @@ export const createIndividualCityClusters = (locations: CountryData[]): ClusterD
       clusterType: "individual_city" as const,
       hasRecords,
       thumbnailUrl,
+      recordCount,
     };
   });
 };

--- a/src/lib/globe/labelRenderer.ts
+++ b/src/lib/globe/labelRenderer.ts
@@ -80,13 +80,14 @@ export const calculateLabelPosition = (d: ClusterData, htmlElements: ClusterData
  * @param thumbnailUrl - 썸네일 URL (선택)
  * @param isMyGlobe - 나의 지구본 여부
  * @param isFirstGlobe - 최초 지구본 여부
+ * @param recordCount - 해당 도시의 총 여행 기록 개수 (선택)
  * @returns 도시 HTML 문자열
  * @responsibility 개별 도시 마커 HTML 생성
  *
  * @description
  * - 기록 없음 + 타인의 지구본/최초 지구본: + 버튼 없음
  * - 기록 없음 + 나의 지구본: + 버튼 표시
- * - 기록 있음: 썸네일 이미지 표시
+ * - 기록 있음: 썸네일 이미지 표시 (기록이 2개 이상이면 딤드 + "+N" 뱃지 표시)
  */
 export const createCityHTML = (
   styles: CityStyles,
@@ -95,7 +96,8 @@ export const createCityHTML = (
   hasRecords: boolean = true,
   thumbnailUrl?: string,
   isMyGlobe: boolean = true,
-  isFirstGlobe: boolean = false
+  isFirstGlobe: boolean = false,
+  recordCount?: number
 ) => {
   const { dot, horizontalLine, label, actionButton, thumbnailCard } = styles;
 
@@ -170,6 +172,13 @@ export const createCityHTML = (
         style="width: 100%; height: 100%; object-fit: cover; border-radius: 4px;"
         data-thumb="true"
       />
+      ${
+        recordCount && recordCount > 1
+          ? `<div style="position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(0, 0, 0, 0.2); border-radius: 4px; pointer-events: none;">
+        <span style="color: #fff; font-size: 12px; font-weight: 700; letter-spacing: -0.24px;">+${recordCount - 1}</span>
+      </div>`
+          : ""
+      }
     </div>`
         : ""
     }

--- a/src/types/clustering.ts
+++ b/src/types/clustering.ts
@@ -16,6 +16,7 @@ export type ClusterData = {
   isExpanded?: boolean;
   hasRecords?: boolean; // 해당 클러스터에 여행 기록이 있는지 여부
   thumbnailUrl?: string; // 클러스터의 대표 썸네일
+  recordCount?: number; // 해당 클러스터(도시)의 총 여행 기록 개수
 };
 
 export type ClusteringState = {

--- a/src/types/travelPatterns.ts
+++ b/src/types/travelPatterns.ts
@@ -9,6 +9,7 @@ export type CountryData = {
   hasRecords?: boolean; // 해당 국가 내 1개 이상의 도시 기록 여부
   thumbnailUrl?: string; // 가장 최근에 기록된 사진 (대표 이미지)
   thumbnails?: string[]; // 여행기록 썸네일 배열 (최대 2개, 최신순)
+  recordCount?: number; // 해당 도시의 총 여행 기록 개수
   cityCount?: number; // 해당 국가의 도시 수 (초기 앵커링 기준)
   updatedAt?: string; // 최근 기록 시간 (동률 처리 기준, ISO 8601 형식)
 };

--- a/src/utils/diaryThumbnailMapper.ts
+++ b/src/utils/diaryThumbnailMapper.ts
@@ -6,6 +6,7 @@ type DiaryThumbnails = {
   cityThumbnails: Record<number, string>;
   countryThumbnails: Record<string, string>;
   cityThumbnailsArray: Record<number, string[]>; // 도시별 최대 2개의 썸네일 배열
+  cityDiaryCount: Record<number, number>; // 도시별 총 여행 기록(다이어리) 개수
 };
 
 /**
@@ -27,11 +28,13 @@ export const getDiaryThumbnails = (
       cityThumbnails: {},
       countryThumbnails: {},
       cityThumbnailsArray: {},
+      cityDiaryCount: {},
     };
   }
 
   const cityThumbnailMap: Record<number, string> = {};
   const cityThumbnailsArrayMap: Record<number, string[]> = {}; // 도시별 썸네일 배열
+  const cityDiaryCountMap: Record<number, number> = {}; // 도시별 총 기록 개수
   const countryDiariesMap: Record<string, Array<{ thumbnailUrl: string; timestamp: number }>> = {};
 
   // 각 diaryResponse를 순회 (이미 city별로 그룹화되어 있음)
@@ -44,6 +47,8 @@ export const getDiaryThumbnails = (
 
     const cityId = city.cityId;
     const countryCode = city.countryCode;
+
+    cityDiaryCountMap[cityId] = diaries.length;
 
     // diaries를 updatedAt 또는 createdAt 기준으로 정렬 (최신 순)
     const sortedDiaries = [...diaries].sort((a, b) => {
@@ -112,5 +117,6 @@ export const getDiaryThumbnails = (
     cityThumbnails: cityThumbnailMap,
     countryThumbnails: countryThumbnailMap,
     cityThumbnailsArray: cityThumbnailsArrayMap,
+    cityDiaryCount: cityDiaryCountMap,
   };
 };

--- a/src/utils/globeDataMapper.ts
+++ b/src/utils/globeDataMapper.ts
@@ -20,7 +20,8 @@ const REGION_COLORS = [
 export const mapGlobeDataToTravelPatterns = (
   globeData: GlobeData,
   cityThumbnails?: Record<number, string>,
-  cityThumbnailsArray?: Record<number, string[]>
+  cityThumbnailsArray?: Record<number, string[]>,
+  cityDiaryCount?: Record<number, number>
 ): TravelPattern[] => {
   if (!globeData.regions || globeData.regions.length === 0) return [];
 
@@ -44,6 +45,7 @@ export const mapGlobeDataToTravelPatterns = (
       const countryName = getCountryName(countryCode);
       const thumbnailUrl = cityThumbnails?.[cityId];
       const thumbnails = cityThumbnailsArray?.[cityId];
+      const recordCount = cityDiaryCount?.[cityId];
 
       // 국가별 도시 수 집계
       if (!countryStats.has(countryCode)) {
@@ -64,6 +66,7 @@ export const mapGlobeDataToTravelPatterns = (
         hasRecords: !!thumbnailUrl || (thumbnails?.length ?? 0) > 0, // 썸네일이 있으면 기록이 있는 것으로 간주
         thumbnailUrl, // 도시별 최신 사진 썸네일 (없으면 undefined)
         thumbnails, // 도시별 썸네일 배열 (최대 2개, 최신순)
+        recordCount, // 도시별 총 여행 기록 개수
         cityId, // API에서 제공하는 도시 ID
       });
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

https://globber-app.atlassian.net/browse/GLB-59

## 📝작업 내용

https://www.figma.com/design/IQQ2UpFkbsmG7u0MnfwvaO/%EC%9D%BC%EA%B0%9C%EB%AF%B8%EC%9D%BC%EB%8B%B9%EB%B0%B1%EC%9D%BC%EB%8B%A8%ED%95%B4?node-id=4019-20048&t=8gdXqzu90SmxArAe-4
- 동일 도시 재기록 어포던스 figma 참고

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 도시별 여행 기록 수가 지도와 도시 카드에 표시됩니다.
  * 여러 기록이 있는 도시는 최신 썸네일과 함께 추가 기록 수 배지를 표시합니다.
  * 지도 도시 라벨에서도 추가 기록 수를 확인할 수 있습니다.

* **개선**
  * 도시별 기록 수를 기반으로 여행 패턴 정보가 더욱 정확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->