### PR TITLE
[GLB-77] heic 변환 실패 시 원본 파일이 그대로 업로드되던 문제 수정

### DIFF
--- a/src/components/imageMetadata/hooks/useImageMetadata.ts
+++ b/src/components/imageMetadata/hooks/useImageMetadata.ts
@@ -208,6 +208,11 @@ export const useImageMetadata = ({ diaryId, isEditMode }: UseImageMetadataProps)
           )
           .map(r => r.value);
 
+        const hasFailure = settled.some(r => r.status === "rejected");
+        if (hasFailure) {
+          alert("업로드에 실패했습니다");
+        }
+
         if (results.length === 0) return;
 
         const uploadPromises = results.map(({ metadata, uploadFile }) =>

--- a/src/lib/processFile.ts
+++ b/src/lib/processFile.ts
@@ -58,37 +58,27 @@ export async function processSingleFile(file: File): Promise<{ metadata: ImageMe
   let uploadFile: File = file;
 
   if (isHeic) {
-    try {
-      const { default: heic2any } = await import("heic2any");
-      const converted = await heic2any({
-        blob: file as unknown as Blob,
-        toType: "image/jpeg",
-        quality: 0.92,
-      });
-      const jpegBlob = Array.isArray(converted) ? converted[0] : converted;
-      if (jpegBlob instanceof Blob) {
-        // 미리보기 URL 교체 (메모리 누수 방지: 기존 Object URL 해제)
-        const newUrl = URL.createObjectURL(jpegBlob);
-        URL.revokeObjectURL(extracted.imagePreview);
-        extracted.imagePreview = newUrl;
-
-        // S3 업로드용 JPEG File 객체 생성 (.heic → .jpg, MIME 타입 image/jpeg)
-        const jpegFileName = file.name.replace(/\.(heic|heif)$/i, ".jpg");
-        uploadFile = new File([jpegBlob], jpegFileName, { type: "image/jpeg" });
-      }
-    } catch {
-      try {
-        const thumb = await exifr.thumbnail(file);
-        if (thumb) {
-          // Uint8Array를 새로운 Uint8Array로 복사하여 타입 안전성 확보
-          const thumbArray = new Uint8Array(thumb);
-          // 메모리 누수 방지: 기존 Object URL 해제
-          const newUrl = URL.createObjectURL(new Blob([thumbArray], { type: "image/jpeg" }));
-          URL.revokeObjectURL(extracted.imagePreview);
-          extracted.imagePreview = newUrl;
-        }
-      } catch {}
+    // HEIC → JPEG 변환 실패 시 원본 HEIC를 그대로 업로드하지 않도록,
+    // 실패를 삼키지 않고 호출부(useImageMetadata)로 전파해 업로드 자체를 막는다.
+    const { default: heic2any } = await import("heic2any");
+    const converted = await heic2any({
+      blob: file as unknown as Blob,
+      toType: "image/jpeg",
+      quality: 0.92,
+    });
+    const jpegBlob = Array.isArray(converted) ? converted[0] : converted;
+    if (!(jpegBlob instanceof Blob)) {
+      throw new Error(`HEIC 변환에 실패했습니다: ${file.name}`);
     }
+
+    // 미리보기 URL 교체 (메모리 누수 방지: 기존 Object URL 해제)
+    const newUrl = URL.createObjectURL(jpegBlob);
+    URL.revokeObjectURL(extracted.imagePreview);
+    extracted.imagePreview = newUrl;
+
+    // S3 업로드용 JPEG File 객체 생성 (.heic → .jpg, MIME 타입 image/jpeg)
+    const jpegFileName = file.name.replace(/\.(heic|heif)$/i, ".jpg");
+    uploadFile = new File([jpegBlob], jpegFileName, { type: "image/jpeg" });
   }
 
   try {


### PR DESCRIPTION
## #️⃣연관된 이슈

https://globber-app.atlassian.net/browse/GLB-77
https://globber-app.atlassian.net/browse/GLB-79

## 📝작업 내용

이슈 리포트: HEIC 이미지 업로드 시 일부 파일이 깨지는 문제

**증상**

일부 .heic 이미지가 업로드 후 화면에서 깨져서 보임. curl -I로 비교한 결과:
<img width="317" height="132" alt="image" src="https://github.com/user-attachments/assets/72b13dff-8747-43f6-8561-1a95d93cb735" />
<img width="317" height="132" alt="image" src="https://github.com/user-attachments/assets/e29eed62-310b-411d-9f2a-85b333c4c052" />
위 : 정상 이미지
아래 : 깨지는 이미지

**깨지는 이미지는 Content-Type이 image/heic로, 변환되지 않은 상태로 업로드 되어있음.**


같은 .heic 확장자인데도 일부만 문제가 발생했고, 재업로드하면 정상적으로 올라감

**원인**

이미지 업로드는 서버가 아닌 프론트엔드에서 heic2any 라이브러리로 HEIC를 JPEG으로 변환한 뒤 S3에 올리는 구조 (src/lib/processFile.ts). 
S3에 전송되는 Content-Type은 하드코딩이 아니라, 업로드하는 File 객체의 실제 .type 값을 그대로 사용함 (diaryService.ts).

문제는 processFile.ts의 변환 실패 처리 로직에 있었음:

```
if (isHeic) {
  try {
    // heic2any로 JPEG 변환 시도
    uploadFile = new File([jpegBlob], jpegFileName, { type: "image/jpeg" }); // 성공 시만
교체
  } catch {
    // 실패 시 미리보기용 thumbnail)
    // → uploadFile은 재할당되지 않고 원본 HEIC 그대로 유지됨
  }
}
```

heic2any는 브라우저에서 JS/WASM으로 HEIC를 디코딩하는데, 파일 용량이 크거나 특정 인코딩 변형, 브라우저 메모리 제약 등의 요인으로 순간적으로 디코딩에 실패할 수 있음. 그런데 이 실패가 catch로 조용히 삼켜지고, 화면 미리보기만 다른 방식(exifr)으로 보정된 채 실제로는 변환되지 않은 원본 HEIC 파일이 그대로 S3에 업로드되고 있었음. 
이것이 재업로드 시 정상적으로 되는 이유(같은 파일이라도 변환 시도마다 성공/실패가 갈릴 수 있음)와, Content-Type이 image/heic로 찍히고 용량이 더 작이 원본 그대로 전송)를 모두 설명함.

**해결**

1. src/lib/processFile.ts — 변환 실패 시 원본으로 조용히 폴백하던 로직을 제거하고, 실패를 에러로 던져 상위 호출부로 전파하도록 변경.
2. src/components/imageMetadata/— 업로드처리(handleFileUpload)에서 변환 실패(rejected)가 하나라도 있으면 alert("업로드에 실패했습니다")를 띄우고, 실패한 파일은 업로드 대상에서 제외해 변환되지 않은 원본이 S3로 전송되는 경로 자체를 차단. 같은 지는 영향 없이 그대로 업로드됨.