### PR TITLE
[GLB-92]: 기록 작성 화면 텍스트 입력 시 iOS 자동 줌인 방지 및 헤더 고정

### DIFF
--- a/src/app/image-metadata/page.tsx
+++ b/src/app/image-metadata/page.tsx
@@ -1,5 +1,14 @@
+import type { Viewport } from "next";
+
 import { ImageMetadataComponent } from "@/components/imageMetadata/ImageMetadata";
 import type { PageProps } from "@/types/components";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
 
 type ImageMetadataQuery = {
   cityId?: string;

--- a/src/components/imageMetadata/ImageMetadata.tsx
+++ b/src/components/imageMetadata/ImageMetadata.tsx
@@ -166,6 +166,7 @@ export const ImageMetadataComponent = ({
         rightButtonTitle="저장"
         rightButtonDisabled={!hasImages || isProcessing || isInitialLoading || !isCityIdValid}
         onRightClick={handleSaveClick}
+        className="sticky top-0 z-50"
       />
       <ImageUploadSection
         metadataList={metadataList}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
[GLB-92](https://globber-app.atlassian.net/browse/GLB-92?atlOrigin=eyJpIjoiODE2ZjgwMDRjZTE4NDMwNjkyYjEyMzhiODg4ZDk2OGIiLCJwIjoiaiJ9)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기록 작성 화면(`/image-metadata`)에서 텍스트 입력 영역을 탭할 때 발생하는 iOS 자동 줌인 현상을 수정하고, 입력 중에도 헤더 저장 버튼에 항상 접근할 수 있도록 개선합니다.

### 문제 상황
- 텍스트 입력 영역 탭 시 iOS Safari/Chrome에서 화면이 자동으로 줌인됨
- 줌인 이후 헤더 영역이 화면 밖으로 밀려나 우측 상단 **저장 버튼**을 누를 수 없음

### 원인
- iOS Safari는 `font-size`가 16px 미만인 입력 요소에 포커스 시 자동으로 확대 처리함
- 헤더가 일반 문서 플로우에 배치되어 있어 스크롤/뷰포트 변경 시 화면 밖으로 사라짐

### 변경 내용

### `src/app/image-metadata/page.tsx`
- `viewport` 메타데이터 export 추가
- `maximum-scale=1`, `user-scalable=no` 설정으로 해당 페이지에서만 자동 줌인 차단
- 다른 페이지에는 영향 없음

### `src/components/imageMetadata/ImageMetadata.tsx`
- 헤더 컴포넌트에 `sticky top-0 z-50` 클래스 추가
- 키보드 노출 및 스크롤 시에도 저장 버튼이 항상 화면 상단에 고정됨

## 테스트 방법
> ⚠️ **배포 후 실제 모바일 환경에서 테스트해야 합니다.**
> viewport 관련 동작은 PC 브라우저 개발자 도구의 모바일 시뮬레이터로는 정확히 재현되지 않습니다.

- [ ] iOS Safari에서 텍스트 입력 영역 탭 시 자동 줌인이 발생하지 않는지 확인
- [ ] iOS Chrome에서 동일하게 확인
- [ ] 텍스트 입력 중 헤더의 저장 버튼이 항상 화면에 노출되는지 확인
- [ ] 저장 버튼 탭 후 정상적으로 저장이 완료되는지 확인

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모바일 화면에서 확대·축소를 제한하고 기기 너비에 맞게 표시되도록 개선했습니다.

* **개선 사항**
  * 페이지 상단 헤더가 스크롤 시에도 고정되어 더욱 편리하게 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->