### PR TITLE
[GLB-91]: 모바일 크롬에서 이미지 드래그 시 저장 팝업 차단

### DIFF
--- a/src/components/imageMetadata/ImageCarousel.tsx
+++ b/src/components/imageMetadata/ImageCarousel.tsx
@@ -223,6 +223,7 @@ export const ImageCarousel = ({
             });
             setIsCropModalOpen(true);
           }}
+          onContextMenu={e => e.preventDefault()}
           aria-label="이미지 편집"
           disabled={isCropUploading}
         >
@@ -234,6 +235,7 @@ export const ImageCarousel = ({
             className="object-cover"
             unoptimized
             draggable={false}
+            onContextMenu={e => e.preventDefault()}
           />
           {isCropUploading && (
             <div className="absolute inset-0 bg-black/60 flex items-center justify-center">


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
[GLB-91](https://globber-app.atlassian.net/browse/GLB-91?atlOrigin=eyJpIjoiODJmN2IyMTYzN2U3NDA2NjkxYzEyODU2MGM2MTc1YmIiLCJwIjoiaiJ9)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 문제
- 이미지 카드를 드래그앤드롭으로 순서 변경 시, 모바일 크롬에서 이미지를 길게 누르면 "이미지 저장" 팝업이 노출되는 문제

### 원인
- Safari는 CSS -webkit-touch-callout: none으로 차단 가능
- Chrome은 해당 CSS를 무시하며, contextmenu JS 이벤트로만 차단 가능
- 기존 SortableImageCard에 onContextMenu 방지가 있었으나, <Image> 및 감싸는 <button>에는 누락

### 수정
- ImageCarousel 내 이미지를 감싸는 <button>과 <Image> 컴포넌트에 onContextMenu={e => e.preventDefault()} 추가

> ⚠️ 배포 후 실제 모바일 환경에서 테스트해야 합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
