### PR TITLE
fix: 저장된 지구본 -> 프로필 사진이 없는 친구에게 디폴트 프로필 이미지가 보이지 않음

### DIFF
--- a/src/components/saved-globe/SavedGlobeClient.tsx
+++ b/src/components/saved-globe/SavedGlobeClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 import { sendGAEvent } from "@next/third-parties/google";
@@ -152,7 +153,13 @@ const GlobeList = ({
                   // eslint-disable-next-line @next/next/no-img-element
                   <img src={profileImageUrl} alt={nickname} className="w-full h-full object-cover" />
                 ) : (
-                  <div className="w-full h-full bg-linear-to-br from-[rgba(0,217,255,0.3)] to-[rgba(0,217,255,0.1)]" />
+                  <Image
+                    src="/assets/default-profile.png"
+                    alt={nickname}
+                    width={44}
+                    height={44}
+                    className="w-full h-full object-cover"
+                  />
                 )}
               </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

[GLB-84](https://globber-app.atlassian.net/browse/GLB-84)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 원인: SavedGlobeClient에서 프로필 사진이 없을 경우 fallback 이미지가 설정되어있지 않음
- 해결: default profile 이미지로 변경하여 해결

### 스크린샷 (선택)

<img width="504" height="325" alt="image" src="https://github.com/user-attachments/assets/fe1ad196-1c83-455c-abb9-8a7cf5ec4d4f" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 프로필 이미지가 없는 경우 기본 프로필 이미지가 표시되도록 개선했습니다.
  * 기본 이미지 렌더링을 최적화해 더욱 일관된 화면 표시를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->